### PR TITLE
analyse error: Unable to get artifact

### DIFF
--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -107,7 +107,7 @@ governing permissions and limitations under the License.
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>sling-feature-converter-maven-plugin</artifactId>
-      <version>1.0.8</version>
+      <version>1.0.9-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AnalyseMojo.java
@@ -12,6 +12,10 @@
 
 package com.adobe.aem.analyser.mojos;
 
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
+import org.apache.maven.artifact.repository.MavenArtifactRepository;
+import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
@@ -20,6 +24,8 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.sling.feature.maven.mojos.AnalyseFeaturesMojo;
 import org.apache.sling.feature.maven.mojos.Scan;
 
+import java.io.File;
+import java.net.MalformedURLException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -50,6 +56,17 @@ public class AnalyseMojo extends AnalyseFeaturesMojo {
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
+        try {
+            List<ArtifactRepository> repos = project.getRemoteArtifactRepositories();
+            File conversionLocalRepo = MojoUtils.getConversionOutputDir(project);
+            ArtifactRepository ar = new MavenArtifactRepository("cp2fm-generated",
+                    conversionLocalRepo.toURI().toURL().toString(), new DefaultRepositoryLayout(),
+                    new ArtifactRepositoryPolicy(), new ArtifactRepositoryPolicy());
+            repos.add(ar);
+        } catch (MalformedURLException e) {
+            throw new MojoExecutionException("Problem configuring output of conversion as local repository", e);
+        }
+
         if (taskConfiguration == null) {
             taskConfiguration = new HashMap<>();
         }


### PR DESCRIPTION
Adding the generated local repository from the cpconverter to the list of repositories for artifact resolution.

I am adding the extra repository as a 'remote' repository as you can only have one local repository which is typically the `~/.m2` directory.

This closes #9