### PR TITLE
Enable the repoinit analyser by default

### DIFF
--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AnalyseMojo.java
@@ -49,7 +49,8 @@ public class AnalyseMojo extends AnalyseFeaturesMojo {
         + "api-regions,"
         + "api-regions-check-order,"
         + "api-regions-crossfeature-dups,"
-        + "api-regions-exportsimports",
+        + "api-regions-exportsimports,"
+        + "repoinit",
         property = "includeTasks")
     List<String> includeTasks;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The repoinit plug-in is quick, does nothing if no repoinit extensions are present and is very useful. We should enable it by default.

<!--- Describe your changes in detail -->

## Related Issue

#18 

## Motivation and Context

See issue.

## How Has This Been Tested?

Ran the maven build.

## Screenshots (if appropriate):

Not applicable.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
