### PR TITLE
Improve error output by deduplicating error messages

### DIFF
--- a/aemanalyser-maven-plugin/README.md
+++ b/aemanalyser-maven-plugin/README.md
@@ -1,14 +1,12 @@
 ## AEM Analyser Maven Plugin
 
-A Maven plugin used by developers who develop Java components for AEMaaCS 
-(AEM as a Cloud Service) during their local Java 
-builds to ensure that their components work correctly when deployed.
+A Maven plugin used by developers who develop applications for AEM as a Cloud Service (AEMaaCS).
+The plugin runs the same checks locally as in the Cloud Service pipeline and ensures that the application works correctly when deployed in the cloud. 
 
 ## Functionality
 
-Provide an easy way for AEMaaCS users to run analysers with their components during local 
-builds to ensure these components will also pass the analysers at AEMaaCS deploy time and 
-function as expected at runtime. Analysers are based on the Sling Feature Model Analyser framework: https://github.com/apache/sling-org-apache-sling-feature-analyser/blob/master/readme.md
+Provide an easy way for AEMaaCS developers to run analysers with their application during local builds to ensure the application code will also pass the analysers at AEMaaCS deploy time and 
+function as expected at runtime. Analysers are based on the Apache Sling Feature Model Analyser framework: https://github.com/apache/sling-org-apache-sling-feature-analyser/blob/master/readme.md
 
 ## Installation
 
@@ -44,7 +42,7 @@ The analyser plugin will run the default set of analysers on the content package
         <aem.sdk.api>2020.11.4506.20201112T235200Z-201028</aem.sdk.api>
 ```
 
-With that, you project pom.xml needs to look somewhat like this:
+With that, your project pom.xml needs to look somewhat like this:
 
 ```
 <project>
@@ -122,13 +120,15 @@ As an example, consider adding a new module to the wknd project. All that is nee
 
 #### Selecting Tasks
 
-The plugin will execute a number of default analysers. It's possible to select a different set of
+The plugin will execute a number of default analysers. It is possible to select a different set of
 analyser tasks, for example with the following configuration:
 
     <includeTasks>
         <includeTask>bundle-packages</includeTask>
         <includeTask>requirements-capabilities</includeTask>
     </includeTasks>
+
+Please note that if you remove tasks which are run by default, the plugin might not report any errors in your project, while the analysers run as part of the AEM as a Cloud Service pipeline might report errors. 
 
 #### Configuring Analyser Tasks
 
@@ -147,6 +147,8 @@ default set of analysers. Additional or different configuration can be provided 
             <order>global,myregion</order>
         </api-regions-check-order>
     </taskConfiguration>
+
+Please note, that overriding the default configuration for the analysers might hide errors locally that will be catched in the Cloud Service pipeline.
 
 ### Maven Goals
 

--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -128,11 +128,5 @@ governing permissions and limitations under the License.
       <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
-  
-    <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>slingfeature-maven-plugin</artifactId>
-      <version>1.5.0</version>
-    </dependency>
   </dependencies>
 </project>

--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -128,5 +128,11 @@ governing permissions and limitations under the License.
       <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
+  
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>slingfeature-maven-plugin</artifactId>
+      <version>1.5.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -107,7 +107,7 @@ governing permissions and limitations under the License.
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>slingfeature-maven-plugin</artifactId>
-      <version>1.4.24</version>
+      <version>1.5.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/AemAnalyser.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/AemAnalyser.java
@@ -1,0 +1,218 @@
+/*
+  Copyright 2020 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.analyser.Analyser;
+import org.apache.sling.feature.analyser.AnalyserResult;
+import org.apache.sling.feature.builder.ArtifactProvider;
+import org.apache.sling.feature.scanner.Scanner;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AemAnalyser {
+
+    public static final String DEFAULT_TASKS = "requirements-capabilities,"
+    + "bundle-content,"
+    + "bundle-resources,"
+    + "bundle-nativecode,"
+    + "api-regions,"
+    + "api-regions-check-order,"
+    + "api-regions-crossfeature-dups,"
+    + "api-regions-exportsimports,"
+//        + "repoinit," disable until SLING-10215 is fixed
+    + "configuration-api";
+
+    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+    private ArtifactProvider artifactProvider;
+
+    private Set<String> includedTasks;
+
+    private Map<String, Map<String, String>> taskConfigurations;
+
+    public AemAnalyser() {
+        this.setIncludedTasks(new LinkedHashSet<>(Arrays.asList(DEFAULT_TASKS.split(","))));
+        this.setTaskConfigurations(new HashMap<>());
+    }
+    
+    /**
+     * @return the includedTasks
+     */
+    public Set<String> getIncludedTasks() {
+        return includedTasks;
+    }
+
+    /**
+     * @param includedTasks the includedTasks to set
+     */
+    public void setIncludedTasks(final Set<String> includedTasks) {
+        this.includedTasks = includedTasks;
+    }
+
+    /**
+     * @return the taskConfigurations
+     */
+    public Map<String, Map<String, String>> getTaskConfigurations() {
+        return taskConfigurations;
+    }
+
+    /**
+     * @param taskConfigurations the taskConfigurations to set
+     */
+    public void setTaskConfigurations(final Map<String, Map<String, String>> taskConfigurations) {
+        this.taskConfigurations = taskConfigurations;
+        this.applyDefaultTaskConfigurations();
+    }
+
+    private void applyDefaultTaskConfigurations() {
+        Map<String, Map<String, String>> config = this.getTaskConfigurations();
+    
+        // Set default task configuration
+        if (!config.containsKey("api-regions-crossfeature-dups")) {
+            final Map<String, String> cfd = new HashMap<>();
+            cfd.put("regions", "global,com.adobe.aem.deprecated");
+            cfd.put("definingFeatures", "com.adobe.aem:aem-sdk-api:slingosgifeature:*");
+            cfd.put("warningPackages", "*");
+            config.put("api-regions-crossfeature-dups", cfd);
+        }
+    
+        if (!config.containsKey("api-regions-check-order")) {
+            final Map<String, String> ord = new HashMap<>();
+            ord.put("order", "global,com.adobe.aem.deprecated,com.adobe.aem.internal");
+            config.put("api-regions-check-order", ord);
+        }    
+    }
+
+    /**
+     * @return the artifactProvider
+     */
+    public ArtifactProvider getArtifactProvider() {
+        return artifactProvider;
+    }
+
+    /**
+     * @param artifactProvider the artifactProvider to set
+     */
+    public void setArtifactProvider(final ArtifactProvider artifactProvider) {
+        this.artifactProvider = artifactProvider;
+    }
+
+    private Scanner createScanner() throws IOException {
+        logger.debug("Setting up scanner");
+        final Scanner scanner = new Scanner(this.getArtifactProvider());
+        logger.debug("Scanner successfully set up : {}", scanner);
+
+        return scanner;
+    }
+
+    private Analyser createAnalyser() throws IOException {
+        final Scanner scanner = this.createScanner();
+
+        logger.debug("Setting up analyser with task configurations = {}, included tasks = {}", this.getTaskConfigurations(), this.getIncludedTasks());
+
+        final Analyser analyser = new Analyser(scanner, this.getTaskConfigurations(), this.getIncludedTasks(), null);
+        logger.debug("Analyser successfully set up : {}", analyser);
+
+        return analyser;
+    }
+
+    public AemAnalyserResult analyse(final Collection<Feature> features) throws Exception {
+        final AemAnalyserResult result = new AemAnalyserResult();
+
+        final Analyser analyser = this.createAnalyser();
+
+        final Map<ArtifactId, AnalyserResult> featureResults = new LinkedHashMap<>();
+        for (final Feature f : features) {
+            featureResults.put(f.getId(), analyser.analyse(f, null, null));
+        }
+
+        logOutput(result, featureResults);
+
+        return result;
+    }
+
+    private static final ArtifactId COMMON_ID = ArtifactId.parse("__:__:1");
+
+    private Map<ArtifactId, List<String>> compactErrors(final Map<ArtifactId, AnalyserResult> results, final boolean compactErrors) {
+        final Map<ArtifactId, List<String>> errors = new LinkedHashMap<>();
+
+        List<String> commonMessages = null;
+        for(final Map.Entry<ArtifactId, AnalyserResult> entry : results.entrySet()) {
+            final List<String> msgs = new ArrayList<>(compactErrors ? entry.getValue().getErrors() : entry.getValue().getWarnings());
+            if ( commonMessages == null ) {
+                commonMessages = msgs;
+                errors.put(COMMON_ID, commonMessages);
+            } else {
+                commonMessages.retainAll(msgs);
+                errors.put(entry.getKey(), msgs);
+            }
+        }
+        for(final List<String> msgs : errors.values()) {
+            if ( msgs != commonMessages) {
+                msgs.removeAll(commonMessages);
+            }
+        }
+
+        return errors;
+    }
+
+    private void logOutput(final AemAnalyserResult result, final Map<ArtifactId, AnalyserResult> featureResults) {
+        final Map<ArtifactId, List<String>> warnings = compactErrors(featureResults, false);
+        
+        for(final Map.Entry<ArtifactId, List<String>> entry : warnings.entrySet()) {
+            if ( !entry.getValue().isEmpty()) {
+                if ( entry.getKey() == COMMON_ID ) {
+                    result.getErrors().add("Analyser detected the following warnings:");
+                    for(final String msg : entry.getValue() ) {
+                        result.getWarnings().add(msg);
+                    }
+                } else {
+                    result.getErrors().add("Analyser detected the following warnings in feature '" + entry.getKey().toMvnId() + "'.");
+                    for(final String msg : entry.getValue() ) {
+                        result.getWarnings().add(msg);
+                    }
+                }
+            }
+        }
+
+        final Map<ArtifactId, List<String>> errors = compactErrors(featureResults, true);
+        
+        for(final Map.Entry<ArtifactId, List<String>> entry : errors.entrySet()) {
+            if ( !entry.getValue().isEmpty()) {
+                if ( entry.getKey() == COMMON_ID ) {
+                    result.getErrors().add("Analyser detected the following errors:");
+                    for(final String msg : entry.getValue() ) {
+                        result.getErrors().add(msg);
+                    }
+                } else {
+                    result.getErrors().add("Analyser detected the following errors in feature '" + entry.getKey().toMvnId() + "'.");
+                    for(final String msg : entry.getValue() ) {
+                        result.getErrors().add(msg);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/AemAnalyserResult.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/AemAnalyserResult.java
@@ -1,0 +1,57 @@
+/*
+  Copyright 2021 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This class holds the result from an analyse run.
+ */
+public class AemAnalyserResult {
+
+    private final List<String> errors = new ArrayList<>();
+
+    private final List<String> warnings = new ArrayList<>();
+
+    /**
+     * Are there any errors?
+     * @return {@code true} if an error exists
+     */
+    public boolean hasErrors() {
+        return !this.errors.isEmpty();
+    }
+
+    /**
+     * Are there any warnings?
+     * @return {@code true} if a warning exists
+     */
+    public boolean hasWarnings() {
+        return !this.warnings.isEmpty();
+    }
+
+    /**
+     * Get the list of errors. The list is mutable.
+     * @return The list of errors, might be empty.
+     */
+    public List<String> getErrors() {
+        return this.errors;
+    }
+
+    /**
+     * Get the list of warnings. The list is mutable.
+     * @return The list of warnings, might be empty.
+     */
+    public List<String> getWarnings() {
+        return this.warnings;
+    }
+}

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AnalyseMojo.java
@@ -11,19 +11,19 @@
 */
 package com.adobe.aem.analyser.mojos;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+
+import com.adobe.aem.analyser.AemAnalyser;
+import com.adobe.aem.analyser.AemAnalyserResult;
 
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
 import org.apache.maven.artifact.resolver.ArtifactResolver;
@@ -33,37 +33,20 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
-import org.apache.maven.shared.utils.logging.MessageUtils;
 import org.apache.sling.feature.ArtifactId;
 import org.apache.sling.feature.Feature;
-import org.apache.sling.feature.analyser.Analyser;
-import org.apache.sling.feature.analyser.AnalyserResult;
-import org.apache.sling.feature.analyser.AnalyserResult.ArtifactReport;
-import org.apache.sling.feature.analyser.AnalyserResult.ExtensionReport;
 import org.apache.sling.feature.builder.ArtifactProvider;
-import org.apache.sling.feature.builder.FeatureProvider;
 import org.apache.sling.feature.io.artifacts.ArtifactManager;
 import org.apache.sling.feature.io.artifacts.ArtifactManagerConfig;
 import org.apache.sling.feature.maven.ProjectHelper;
 import org.apache.sling.feature.maven.mojos.AbstractIncludingFeatureMojo;
 import org.apache.sling.feature.maven.mojos.FeatureSelectionConfig;
-import org.apache.sling.feature.scanner.Scanner;
 
 @Mojo(name = "analyse", defaultPhase = LifecyclePhase.TEST)
 public class AnalyseMojo extends AbstractIncludingFeatureMojo {
     boolean unitTestMode = false;
 
-    @Parameter(defaultValue =
-        "requirements-capabilities,"
-        + "bundle-content,"
-        + "bundle-resources,"
-        + "bundle-nativecode,"
-        + "api-regions,"
-        + "api-regions-check-order,"
-        + "api-regions-crossfeature-dups,"
-        + "api-regions-exportsimports,"
-//        + "repoinit," disable until SLING-10215 is fixed
-        + "configuration-api",
+    @Parameter(defaultValue = AemAnalyser.DEFAULT_TASKS,
         property = "includeTasks")
     List<String> includeTasks;
 
@@ -102,48 +85,7 @@ public class AnalyseMojo extends AbstractIncludingFeatureMojo {
         };
     }
 
-    protected class BaseFeatureProvider implements FeatureProvider {
-        @Override
-        public Feature provide(ArtifactId id) {
-            // Check for the feature in the local context
-            for (final Feature feat : ProjectHelper.getAssembledFeatures(project).values()) {
-                if (feat.getId().equals(id)) {
-                    return feat;
-                }
-            }
-
-            if (ProjectHelper.isLocalProjectArtifact(project, id)) {
-                throw new RuntimeException("Unable to resolve local artifact " + id.toMvnId());
-            }
-
-            // Finally, look the feature up via Maven's dependency mechanism
-            return ProjectHelper.getOrResolveFeature(project, mavenSession, artifactHandlerManager,
-                artifactResolver, id);
-        }
-    }
-
-    protected FeatureProvider getFeatureProvider() {
-        return new BaseFeatureProvider();
-    }
-
-    private static final String FILE_STORAGE_CONFIG_KEY = "fileStorage";
-
-    private static final String ANALYSER_CONFIG_WILDCARD = "all";
-
-    void addTaskConfigurationDefaults(Map<String, Map<String, String>> taskConfiguration) {
-        String featureModelFileStorage = project.getBuild().getDirectory() + "/sling-slingfeature-maven-plugin-fmtmp";
-        Map<String, String> wildCardCfg = taskConfiguration.get(ANALYSER_CONFIG_WILDCARD);
-        if (wildCardCfg == null) {
-            wildCardCfg = new HashMap<String, String>();
-            taskConfiguration.put(ANALYSER_CONFIG_WILDCARD, wildCardCfg);
-        }
-        if (!wildCardCfg.containsKey(FILE_STORAGE_CONFIG_KEY)) {
-            new File(featureModelFileStorage).mkdirs();
-            wildCardCfg.put(FILE_STORAGE_CONFIG_KEY, featureModelFileStorage);
-        }
-    }
-    
-    Map<String, Map<String, String>> getTaskConfiguration() {
+    Map<String, Map<String, String>> getTaskConfigurations() {
         Map<String, Map<String, String>> config = new HashMap<>();
         if (this.taskConfiguration != null) {
             for(final Map.Entry<String, Properties> entry : this.taskConfiguration.entrySet()) {
@@ -154,22 +96,6 @@ public class AnalyseMojo extends AbstractIncludingFeatureMojo {
             }
         }
 
-        // Set default task configuration
-        if (!config.containsKey("api-regions-crossfeature-dups")) {
-            final Map<String, String> cfd = new HashMap<>();
-            cfd.put("regions", "global,com.adobe.aem.deprecated");
-            cfd.put("definingFeatures", "com.adobe.aem:aem-sdk-api:slingosgifeature:*");
-            cfd.put("warningPackages", "*");
-            config.put("api-regions-crossfeature-dups", cfd);
-        }
-
-        if (!config.containsKey("api-regions-check-order")) {
-            final Map<String, String> ord = new HashMap<>();
-            ord.put("order", "global,com.adobe.aem.deprecated,com.adobe.aem.internal");
-            config.put("api-regions-check-order", ord);
-        }
-
-        addTaskConfigurationDefaults(config);
         return config;
     }
 
@@ -207,106 +133,38 @@ public class AnalyseMojo extends AbstractIncludingFeatureMojo {
 
         checkPreconditions();
  
-        getLog().debug(MessageUtils.buffer().a("Setting up the ").strong("Scanner").a("...").toString());
-        Scanner scanner;
-        try {
-            scanner = new Scanner(getArtifactProvider(getLocalArtifactProvider()));
-        } catch (final IOException e) {
-            throw new MojoExecutionException("A fatal error occurred while setting up the Scanner, see error cause:",
-                    e);
-        }
-        getLog().debug(MessageUtils.buffer().strong("Scanner").a(" successfully set up").toString());
-
-        FeatureProvider featureProvider = getFeatureProvider();
-
+ 
         boolean hasErrors = false;
         try {
-            final Map<String, Map<String, String>> taskConfiguration = this.getTaskConfiguration();
-            final Set<String> includedTasks = this.getIncludedTasks();
-
-            getLog().debug(MessageUtils.buffer().a("Setting up the ").strong("analyser")
-                    .a(" with following configuration:").toString());
-            getLog().debug(" * Task Configuration = " + taskConfiguration);
-            getLog().debug(" * Include Tasks = " + includedTasks);
-            final Analyser analyser = new Analyser(scanner, taskConfiguration, includedTasks, null);
-            getLog().debug(MessageUtils.buffer().strong("Analyser").a(" successfully set up").toString());
-
+            final AemAnalyser analyser = new AemAnalyser();
+            analyser.setArtifactProvider(getArtifactProvider(getLocalArtifactProvider()));
+            analyser.setIncludedTasks(this.getIncludedTasks());
+            analyser.setTaskConfigurations(this.getTaskConfigurations());
+    
             getLog().debug("Retrieving Feature files...");
             final Collection<Feature> features = this.getSelectedFeatures(getFeatureSelection()).values();
 
-            final Map<ArtifactId, AnalyserResult> results = new LinkedHashMap<>();
-            for (final Feature f : features) {
-                try {
-                    getLog().debug(MessageUtils.buffer().a("Analyzing feature ").strong(f.getId().toMvnId())
-                            .a(" ...").toString());
-                    final AnalyserResult result = analyser.analyse(f, null, featureProvider);
-                    results.put(f.getId(), result);
-
-                    hasErrors |= !result.getErrors().isEmpty();
-                } catch (Exception t) {
-                    throw new MojoFailureException(
-                            "Exception during analysing feature " + f.getId().toMvnId() + " : " + t.getMessage(),
-                            t);
-                }
+            final AemAnalyserResult result = analyser.analyse(features);
+            
+            for(final String msg : result.getWarnings()) {
+                getLog().warn(msg);
             }
+            for(final String msg : result.getErrors()) {
+                getLog().error(msg);
+            }
+            hasErrors = result.hasErrors();
 
-            logOutput(results);
-
-        } catch (IOException e) {
-            throw new MojoExecutionException(
-                    "A fatal error occurred while setting up the analyzer, see error cause:", e);
+        } catch ( final Exception e) {
+            throw new MojoExecutionException("A fatal error occurred while analysing the features, see error cause:",
+                    e);
         }
+
         if (hasErrors) {
             if ( failOnAnalyserErrors ) {
                 throw new MojoFailureException(
                     "One or more feature analyser(s) detected feature error(s), please read the plugin log for more details");
             }
             getLog().warn("Errors found during analyser run, but this plugin is configured to ignore errors and continue the build!");
-        }
-    }
-
-    private static final ArtifactId COMMON_ID = ArtifactId.parse("__:__:1");
-
-    private Map<ArtifactId, List<String>> compactErrors(final Map<ArtifactId, AnalyserResult> results) {
-        final Map<ArtifactId, List<String>> errors = new LinkedHashMap<>();
-
-        List<String> commonMessages = null;
-        for(final Map.Entry<ArtifactId, AnalyserResult> entry : results.entrySet()) {
-            final List<String> msgs = new ArrayList<>(entry.getValue().getErrors());
-            if ( commonMessages == null ) {
-                commonMessages = msgs;
-                errors.put(COMMON_ID, commonMessages);
-            } else {
-                commonMessages.retainAll(msgs);
-                errors.put(entry.getKey(), msgs);
-            }
-        }
-        for(final List<String> msgs : errors.values()) {
-            if ( msgs != commonMessages) {
-                msgs.removeAll(commonMessages);
-            }
-        }
-
-        return errors;
-    }
-
-    private void logOutput(final Map<ArtifactId, AnalyserResult> results) {
-        final Map<ArtifactId, List<String>> errors = compactErrors(results);
-        
-        for(final Map.Entry<ArtifactId, List<String>> entry : errors.entrySet()) {
-            if ( !entry.getValue().isEmpty()) {
-                if ( entry.getKey() == COMMON_ID ) {
-                    getLog().error("Analyser detected global errors.");
-                    for(final String msg : entry.getValue() ) {
-                        getLog().error(msg);
-                    }
-                } else {
-                    getLog().error("Analyser detected errors on feature '" + entry.getKey().toMvnId() + "'.");
-                    for(final String msg : entry.getValue() ) {
-                        getLog().error(msg);
-                    }
-                }
-            }
         }
     }
 }

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AnalyseMojo.java
@@ -140,7 +140,7 @@ public class AnalyseMojo extends AbstractIncludingFeatureMojo {
             analyser.setArtifactProvider(getArtifactProvider(getLocalArtifactProvider()));
             analyser.setIncludedTasks(this.getIncludedTasks());
             analyser.setTaskConfigurations(this.getTaskConfigurations());
-    
+
             getLog().debug("Retrieving Feature files...");
             final Collection<Feature> features = this.getSelectedFeatures(getFeatureSelection()).values();
 

--- a/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/AemAnalyserTest.java
+++ b/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/AemAnalyserTest.java
@@ -1,0 +1,99 @@
+/*
+  Copyright 2021 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class AemAnalyserTest {
+    
+    @Test public void testDefaultIncludedTasks() {
+        final AemAnalyser analyser = new AemAnalyser();
+        assertNotNull(analyser.getIncludedTasks());
+        assertEquals(AemAnalyser.DEFAULT_TASKS.split(",").length, analyser.getIncludedTasks().size());
+        for(final String t : AemAnalyser.DEFAULT_TASKS.split(",")) {
+            assertTrue(analyser.getIncludedTasks().contains(t));
+        }
+    }
+
+    @Test public void testDefaultTaskConfigurations() {
+        final AemAnalyser analyser = new AemAnalyser();
+        assertNotNull(analyser.getTaskConfigurations());
+
+        // 2 configs by default
+        assertEquals(2, analyser.getTaskConfigurations().size());
+       
+        // check first config
+        Map<String, String> config = analyser.getTaskConfigurations().get("api-regions-crossfeature-dups");
+        assertNotNull(config);
+        assertEquals(3, config.size());
+        assertEquals("global,com.adobe.aem.deprecated", config.get("regions"));
+        assertEquals("com.adobe.aem:aem-sdk-api:slingosgifeature:*", config.get("definingFeatures"));
+        assertEquals("*", config.get("warningPackages"));
+
+        // check second config
+        config = analyser.getTaskConfigurations().get("api-regions-check-order");
+        assertNotNull(config);
+        assertEquals(1, config.size());
+        assertEquals("global,com.adobe.aem.deprecated,com.adobe.aem.internal", config.get("order"));
+    }
+
+    @Test public void testSetTaskConfigurations() throws Exception {
+        final Map<String, String> myTaskConfig = new HashMap<>();
+        myTaskConfig.put("x", "y");
+        final Map<String, String> overriddenConfig = new HashMap<>();
+        overriddenConfig.put("traa", "laa");
+
+        final Map<String, Map<String, String>> taskConfigurations = new HashMap<>();
+        taskConfigurations.put("mytask", myTaskConfig);
+        taskConfigurations.put("api-regions-crossfeature-dups", overriddenConfig);
+
+        final AemAnalyser analyser = new AemAnalyser();
+        analyser.setTaskConfigurations(taskConfigurations);
+
+        // 3 configurations (2 default + 1 custom)
+        assertEquals(3, analyser.getTaskConfigurations().size());
+
+        // check overridden default config
+        Map<String, String> config = analyser.getTaskConfigurations().get("api-regions-crossfeature-dups");
+        assertNotNull(config);
+        assertEquals(1, config.size());
+        assertEquals("laa", config.get("traa"));
+
+        // check custom config
+        config = analyser.getTaskConfigurations().get("mytask");
+        assertNotNull(config);
+        assertEquals(1, config.size());
+        assertEquals("y", config.get("x"));
+
+        // check second default config - unchanged
+        config = analyser.getTaskConfigurations().get("api-regions-check-order");
+        assertNotNull(config);
+        assertEquals(1, config.size());
+        assertEquals("global,com.adobe.aem.deprecated,com.adobe.aem.internal", config.get("order"));
+    }
+
+    @Test public void testSetIncludedTasks() throws Exception {
+        final AemAnalyser analyser = new AemAnalyser();
+        analyser.setIncludedTasks(Collections.singleton("mytask"));
+
+        assertEquals(1, analyser.getIncludedTasks().size());
+        assertTrue(analyser.getIncludedTasks().contains("mytask"));
+    }
+}

--- a/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/AnalyseMojoTest.java
+++ b/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/AnalyseMojoTest.java
@@ -157,9 +157,7 @@ public class AnalyseMojoTest {
         mojo.unitTestMode = true;
         mojo.includeTasks = Collections.singletonList("mytask");
 
-        mojo.execute();
-
-        ArtifactProvider ap = mojo.getArtifactProvider();
+        ArtifactProvider ap = mojo.getArtifactProvider(mojo.getLocalArtifactProvider());
         URL url = ap.provide(ArtifactId.fromMvnId("a:b:123"));
         assertEquals(ab123.toURI().toURL(), url);
 
@@ -193,9 +191,8 @@ public class AnalyseMojoTest {
         ArtifactManager lam = ArtifactManager.getArtifactManager(amc);
 
         AnalyseMojo mojo = new TestAnalyseMojo(prj);
-        mojo.localArtifactManager = lam;
 
-        ArtifactProvider ap = mojo.getArtifactProvider();
+        ArtifactProvider ap = mojo.getArtifactProvider(lam);
         URL url = ap.provide(ArtifactId.fromMvnId("a:b:123"));
         assertEquals(ab123.toURI().toURL(), url);
 
@@ -220,7 +217,7 @@ public class AnalyseMojoTest {
         Mockito.when(prj.getAttachedArtifacts()).thenReturn(attached);
 
         AnalyseMojo mojo = new TestAnalyseMojo(prj);
-        ArtifactProvider ap = mojo.getArtifactProvider();
+        ArtifactProvider ap = mojo.getArtifactProvider(null);
         URL url = ap.provide(ArtifactId.fromMvnId("a:b:slingosgifeature:123"));
         assertEquals(ab123.toURI().toURL(), url);
 

--- a/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/AnalyseMojoTest.java
+++ b/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/AnalyseMojoTest.java
@@ -19,7 +19,6 @@ import org.apache.sling.feature.ArtifactId;
 import org.apache.sling.feature.builder.ArtifactProvider;
 import org.apache.sling.feature.io.artifacts.ArtifactManager;
 import org.apache.sling.feature.io.artifacts.ArtifactManagerConfig;
-import org.apache.sling.feature.maven.mojos.Scan;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -77,26 +76,21 @@ public class AnalyseMojoTest {
 
         mojo.execute();
 
-        @SuppressWarnings("unchecked")
-        List<Scan> scans = (List<Scan>) TestUtil.getField(
-                mojo, mojo.getClass(), "scans");
-        assertEquals(1, scans.size());
-        Scan scan = scans.get(0);
-        assertEquals(2, scan.getSelections().size());
+        assertEquals(2, mojo.getFeatureSelection().getSelections().size());
 
         Map<String,String> expected = new HashMap<>();
         expected.put("regions", "global,com.adobe.aem.deprecated");
         expected.put("warningPackages", "*");
         expected.put("definingFeatures", "com.adobe.aem:aem-sdk-api:slingosgifeature:*");
         assertEquals("Default task configuration not as expected",
-                expected, scan.getTaskConfiguration().get("api-regions-crossfeature-dups"));
+                expected, mojo.getTaskConfiguration().get("api-regions-crossfeature-dups"));
 
         assertEquals("Default task configuration not as expected",
                 "global,com.adobe.aem.deprecated,com.adobe.aem.internal",
-                scan.getTaskConfiguration().get("api-regions-check-order").get("order"));
+                mojo.getTaskConfiguration().get("api-regions-check-order").get("order"));
 
         // Note getSelections() returns a private type...
-        List<?> sels = scan.getSelections();
+        List<?> sels = mojo.getFeatureSelection().getSelections();
         assertEquals(new HashSet<>(Arrays.asList("agg1", "agg2")),
                 getSelectionInstructions(sels, "CLASSIFIER"));
     }
@@ -121,23 +115,15 @@ public class AnalyseMojoTest {
         mojo.taskConfiguration.put("mytask", myTaskConfig);
         mojo.taskConfiguration.put("api-regions-crossfeature-dups", overriddenConfig);
 
-        mojo.execute();
-
-        @SuppressWarnings("unchecked")
-        List<Scan> scans = (List<Scan>) TestUtil.getField(
-                mojo, mojo.getClass(), "scans");
-        assertEquals(1, scans.size());
-        Scan scan = scans.get(0);
-
-        assertEquals(Collections.singleton("mytask"), scan.getIncludeTasks());
-        assertEquals("y", scan.getTaskConfiguration().get("mytask").get("x"));
+        assertEquals(Collections.singleton("mytask"), mojo.getIncludedTasks());
+        assertEquals("y", mojo.getTaskConfiguration().get("mytask").get("x"));
 
         assertEquals("Overridden task configuration not as expected",
                 Collections.singletonMap("traa", "laa"),
-                scan.getTaskConfiguration().get("api-regions-crossfeature-dups"));
+                mojo.getTaskConfiguration().get("api-regions-crossfeature-dups"));
         assertEquals("Default task configuration not as expected",
                 "global,com.adobe.aem.deprecated,com.adobe.aem.internal",
-                scan.getTaskConfiguration().get("api-regions-check-order").get("order"));
+                mojo.getTaskConfiguration().get("api-regions-check-order").get("order"));
     }
 
     @Test

--- a/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/AnalyseMojoTest.java
+++ b/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/AnalyseMojoTest.java
@@ -12,6 +12,21 @@
 
 package com.adobe.aem.analyser.mojos;
 
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Build;
 import org.apache.maven.project.MavenProject;
@@ -23,24 +38,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-
-import static org.junit.Assert.assertEquals;
 
 public class AnalyseMojoTest {
 
@@ -78,53 +75,13 @@ public class AnalyseMojoTest {
 
         assertEquals(2, mojo.getFeatureSelection().getSelections().size());
 
-        Map<String,String> expected = new HashMap<>();
-        expected.put("regions", "global,com.adobe.aem.deprecated");
-        expected.put("warningPackages", "*");
-        expected.put("definingFeatures", "com.adobe.aem:aem-sdk-api:slingosgifeature:*");
-        assertEquals("Default task configuration not as expected",
-                expected, mojo.getTaskConfiguration().get("api-regions-crossfeature-dups"));
-
-        assertEquals("Default task configuration not as expected",
-                "global,com.adobe.aem.deprecated,com.adobe.aem.internal",
-                mojo.getTaskConfiguration().get("api-regions-check-order").get("order"));
-
         // Note getSelections() returns a private type...
         List<?> sels = mojo.getFeatureSelection().getSelections();
         assertEquals(new HashSet<>(Arrays.asList("agg1", "agg2")),
                 getSelectionInstructions(sels, "CLASSIFIER"));
     }
 
-    @Test
-    public void testAddTaskConfig() throws Exception {
-        MavenProject prj = Mockito.mock(MavenProject.class);
-        Mockito.when(prj.getBuild()).thenReturn(Mockito.mock(Build.class));
-        Mockito.when(prj.getContextValue(AggregateWithSDKMojo.class.getName() + "-aggregates"))
-            .thenReturn(Collections.singleton("aggregates"));
 
-        AnalyseMojo mojo = new TestAnalyseMojo(prj);
-        mojo.unitTestMode = true;
-        mojo.includeTasks = Collections.singletonList("mytask");
-
-        Properties myTaskConfig = new Properties();
-        myTaskConfig.put("x", "y");
-        Properties overriddenConfig = new Properties();
-        overriddenConfig.put("traa", "laa");
-
-        mojo.taskConfiguration = new HashMap<>();
-        mojo.taskConfiguration.put("mytask", myTaskConfig);
-        mojo.taskConfiguration.put("api-regions-crossfeature-dups", overriddenConfig);
-
-        assertEquals(Collections.singleton("mytask"), mojo.getIncludedTasks());
-        assertEquals("y", mojo.getTaskConfiguration().get("mytask").get("x"));
-
-        assertEquals("Overridden task configuration not as expected",
-                Collections.singletonMap("traa", "laa"),
-                mojo.getTaskConfiguration().get("api-regions-crossfeature-dups"));
-        assertEquals("Default task configuration not as expected",
-                "global,com.adobe.aem.deprecated,com.adobe.aem.internal",
-                mojo.getTaskConfiguration().get("api-regions-check-order").get("order"));
-    }
 
     @Test
     public void testLocalArtifactManager() throws Exception {


### PR DESCRIPTION
If there are analyser errors, the messages are spread across the output. In addition if its a "global" error that applies to all features, it is repeated for each and every feature.

## Description

Instead of inheriting from the Apache Sling analyse mojo, with this PR it is up to this maven plugin to define the output of the analysers. This way we are more flexible and can create a report at the end of the analyser run. In addition we can compact the error messages and avoid logging the same error several times.

The output can potentially even be more improved, this PR provides a starting point

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
