### PR TITLE
Use latest SDK version. This closes #48

### DIFF
--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -193,11 +193,6 @@ governing permissions and limitations under the License.
       <version>2.0</version>
     </dependency>
 
-    <dependency>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>versions-maven-plugin</artifactId>
-        <version>2.8.1</version>
-    </dependency>
     <!-- Test -->
     <dependency>
       <groupId>junit</groupId>

--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -168,6 +168,11 @@ governing permissions and limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.repoinit.parser</artifactId>
+      <version>1.6.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.feature.analyser</artifactId>
       <version>1.3.24</version>
     </dependency>
@@ -186,6 +191,12 @@ governing permissions and limitations under the License.
       <groupId>javax.jcr</groupId>
       <artifactId>jcr</artifactId>
       <version>2.0</version>
+    </dependency>
+
+    <dependency>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.8.1</version>
     </dependency>
     <!-- Test -->
     <dependency>

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
@@ -136,9 +136,6 @@ public class AemAnalyseMojo extends AbstractMojo {
     protected MavenSession mavenSession;
 
     @Component
-    private org.apache.maven.artifact.factory.ArtifactFactory artifactFactory;
-
-    @Component
     private ArtifactMetadataSource artifactMetadataSource;
 
     @Parameter(defaultValue = "${project.remoteArtifactRepositories}", readonly = true)
@@ -195,8 +192,8 @@ public class AemAnalyseMojo extends AbstractMojo {
             return;
         }
 
-        final VersionUtil versionUtil = new VersionUtil(this.getLog(), this.project, this.artifactResolver, 
-                this.mavenSession, this.artifactFactory, this.artifactMetadataSource, 
+        final VersionUtil versionUtil = new VersionUtil(this.getLog(), this.project, 
+                this.artifactHandlerManager, this.artifactMetadataSource, 
                 this.remoteArtifactRepositories, this.localRepository);
 
         final ArtifactId sdkId = versionUtil.getSDKArtifactId(this.sdkArtifactId, this.sdkVersion, this.useDependencyVersions);

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
@@ -69,17 +69,25 @@ import org.codehaus.mojo.versions.api.VersionsHelper;
 public class AemAnalyseMojo extends AbstractMojo {
 
     /**
-     * The artifact id of the sdk api jar
+     * The artifact id of the sdk api jar. The artifact id is automatically detected by this plugin,
+     * but using this configuration the auto detection can be disabled
      */
     @Parameter(defaultValue = Constants.SDK_ARTIFACT_ID, property = "sdkArtifactId")
     String sdkArtifactId;
     
     /**
-     * The version of the sdk api. Can be used to specify the exact version to be used. Otherwise the latest
-     * available SDK version is used.
+     * The version of the sdk api. Can be used to specify the exact version to be used. Otherwise the
+     * plugin detects the version to use.
      */
     @Parameter(required = false, property = "sdkVersion")
     String sdkVersion;
+
+    /**
+     * Use dependency versions. If this is enabled, the version for the SDK and the Add-ons is taken
+     * from the project dependencies. By default, the latest version is used.
+     */
+    @Parameter(required = false, defaultValue = "false")
+    boolean useDependencyVersions;
 
     /**
      * The list of add ons.
@@ -298,7 +306,7 @@ public class AemAnalyseMojo extends AbstractMojo {
             dep.setGroupId(Constants.SDK_GROUP_ID);
             dep.setArtifactId(this.sdkArtifactId);
             dep.setVersion(sdkDep == null ? "1.0" : sdkDep.getVersion());
-            final String foundVersion = this.getLatestVersion(dep);
+            final String foundVersion = this.useDependencyVersions ? null : this.getLatestVersion(dep);
             if ( foundVersion == null && sdkDep == null ) {
                 throw new MojoExecutionException("Unable to find SDK artifact in dependencies or dependency management: "
                                     + Constants.SDK_GROUP_ID + ":" + this.sdkArtifactId);
@@ -338,7 +346,7 @@ public class AemAnalyseMojo extends AbstractMojo {
                 dep.setGroupId(addonSDK.getGroupId());
                 dep.setArtifactId(addonSDK.getArtifactId());
                 dep.setVersion(addonSDK.getVersion());
-                final String foundVersion = this.getLatestVersion(dep);
+                final String foundVersion = this.useDependencyVersions ? null : this.getLatestVersion(dep);
                 String useVersion = dep.getVersion();
                 if ( foundVersion != null && isNewer(useVersion, foundVersion)) {
                     getLog().warn("Project is configured with outdated Add-On version : " + dep);

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/Constants.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/Constants.java
@@ -20,9 +20,11 @@ public abstract class Constants {
     public static final String SDK_GROUP_ID = "com.adobe.aem";
 
     /** The artifact id for the SDK */
-
     public static final String SDK_ARTIFACT_ID = "aem-sdk-api";
     
+    /** The artifact id for the prerelease SDK */
+    public static final String SDK_PRERELEASE_ARTIFACT_ID = "aem-prerelease-sdk-api";
+
     /** The default addons */
     public static final List<Addon> DEFAULT_ADDONS =
             Arrays.asList(

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/VersionUtil.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/VersionUtil.java
@@ -1,0 +1,307 @@
+/*
+  Copyright 2020 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser.mojos;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.artifact.metadata.ArtifactMetadataRetrievalException;
+import org.apache.maven.artifact.metadata.ArtifactMetadataSource;
+import org.apache.maven.artifact.factory.ArtifactFactory;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.artifact.resolver.ArtifactResolver;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Dependency;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.sling.feature.ArtifactId;
+import org.codehaus.mojo.versions.api.ArtifactVersions;
+import org.codehaus.mojo.versions.api.DefaultVersionsHelper;
+import org.codehaus.mojo.versions.api.UpdateScope;
+import org.codehaus.mojo.versions.api.VersionsHelper;
+
+/**
+ * Helper methods to manage dependencies, versions, ...
+ */
+public class VersionUtil {
+
+    private final MavenProject project;
+
+    private final Log log;
+
+    private final ArtifactResolver artifactResolver;
+
+    private final MavenSession mavenSession;
+
+    private final ArtifactFactory artifactFactory;
+
+    private final ArtifactMetadataSource artifactMetadataSource;
+
+    private final List<ArtifactRepository> remoteArtifactRepositories;
+
+    private final ArtifactRepository localRepository;
+
+    public VersionUtil(final Log log, 
+            final MavenProject project,
+            final ArtifactResolver artifactResolver,
+            final MavenSession mavenSession,
+            final ArtifactFactory artifactFactory,
+            final ArtifactMetadataSource artifactMetadataSource,
+            final List<ArtifactRepository> remoteArtifactRepositories,
+            final ArtifactRepository localRepository) {
+        this.project = project;
+        this.log = log;
+        this.artifactResolver = artifactResolver;
+        this.mavenSession = mavenSession;
+        this.artifactFactory = artifactFactory;
+        this.artifactMetadataSource = artifactMetadataSource;
+        this.remoteArtifactRepositories = remoteArtifactRepositories;
+        this.localRepository = localRepository;
+    }
+
+    /**
+     * Get the list of addons
+     * @param addons Configured add ons
+     * @return The list of discovered addons
+     * @throws MojoExecutionException
+     */
+    List<ArtifactId> discoverAddons(final List<Addon> addons, final boolean useDependencyVersions) throws MojoExecutionException {
+        final List<ArtifactId> result = new ArrayList<>();
+        for (Addon addon : addons == null ? Constants.DEFAULT_ADDONS : addons) {
+            ArtifactId addonSDK = getArtifactIdFromDependencies(addon.groupId, addon.artifactId);
+
+            if (addonSDK != null ) {
+                // check for latest version
+                final Dependency dep = new Dependency();
+                dep.setGroupId(addonSDK.getGroupId());
+                dep.setArtifactId(addonSDK.getArtifactId());
+                dep.setVersion(addonSDK.getVersion());
+                final String foundVersion = useDependencyVersions ? null : this.getLatestVersion(dep);
+                String useVersion = dep.getVersion();
+                if ( foundVersion != null && isNewer(useVersion, foundVersion)) {
+                    this.log.warn("Project is configured with outdated Add-On version : " + dep);
+                    this.log.warn("Please update to version : " + foundVersion);
+                    useVersion = foundVersion;
+                }
+                addonSDK = addonSDK.changeVersion(useVersion);
+
+                this.log.info("Using Add-On for analysis: " + addonSDK);
+
+                result.add(addonSDK);
+            }
+        }
+
+        return result;
+    }
+    
+    /**
+     * Get the SDK artifact id
+     * @return The artifact id of the SDK
+     * @throws MojoExecutionException If the artifact id can't be detected
+     */
+    ArtifactId getSDKArtifactId(
+            final String configuredArtifactId,
+            final String configuredVersion,
+            final boolean useDependencyVersions) throws MojoExecutionException {
+
+        ArtifactId dependencySdk;
+        // if an artifact id is configured, use it to find a project dependency
+        if ( configuredArtifactId != null ) {
+            if ( configuredVersion != null ) {
+                dependencySdk = new ArtifactId(Constants.SDK_GROUP_ID, configuredArtifactId, configuredVersion, null, null);
+            } else {
+                dependencySdk = getArtifactIdFromDependencies(Constants.SDK_GROUP_ID, configuredArtifactId);
+                if ( dependencySdk == null && configuredVersion == null ) {
+                    throw new MojoExecutionException("Unable to find SDK artifact in dependencies or dependency management: "
+                                        + Constants.SDK_GROUP_ID + ":" + configuredArtifactId);
+                }    
+            }
+        } else {
+            // first search prerelease SDK
+            dependencySdk = getArtifactIdFromDependencies(Constants.SDK_GROUP_ID, Constants.SDK_PRERELEASE_ARTIFACT_ID);
+            if ( dependencySdk == null ) {
+                // use SDK
+                dependencySdk = getArtifactIdFromDependencies(Constants.SDK_GROUP_ID, Constants.SDK_ARTIFACT_ID);
+            }
+        }
+
+        // use configured, found or default artifact id
+        final String useArtifactId = dependencySdk != null ? dependencySdk.getArtifactId() : Constants.SDK_ARTIFACT_ID;
+
+        // if a version is configured, use it
+        final ArtifactId result;
+        if ( configuredVersion != null ) {
+            result = new ArtifactId(Constants.SDK_GROUP_ID, useArtifactId, configuredVersion, null, null);
+            this.log.info("Using configured SDK Version for analysis: " + result);
+
+        } else {
+            // check for latest version
+            final Dependency dep = new Dependency();
+            dep.setGroupId(Constants.SDK_GROUP_ID);
+            dep.setArtifactId(useArtifactId);
+            dep.setVersion(dependencySdk == null ? "1.0" : dependencySdk.getVersion());
+            
+            final String foundVersion = useDependencyVersions ? null : getLatestVersion(dep);
+            if ( foundVersion == null && dependencySdk == null ) {
+                throw new MojoExecutionException("Unable to find SDK artifact in dependencies or dependency management: "
+                                    + Constants.SDK_GROUP_ID + ":" + useArtifactId);
+            }
+            String useVersion = dependencySdk != null ? dependencySdk.getVersion() : null;
+            if ( dependencySdk != null && foundVersion != null && isNewer(useVersion, foundVersion)) {
+                this.log.warn("Project is configured with outdated SDK version : " + dependencySdk.getVersion());
+                this.log.warn("Please update to SDK version : " + foundVersion);
+                useVersion = foundVersion;
+            }
+            result = new ArtifactId(Constants.SDK_GROUP_ID, useArtifactId, useVersion, null, null);
+
+            this.log.info("Using detected SDK Version for analysis: " + result);
+        }
+
+        return result;
+    }
+
+    private boolean isNewer(final String existingVersion, final String foundVersion) {
+        if ( foundVersion == null ) {
+            return false;
+        }
+        final ArtifactVersion ev = new DefaultArtifactVersion(existingVersion);
+        final ArtifactVersion fv = new DefaultArtifactVersion(foundVersion);
+        return fv.compareTo(ev) > 0;
+    }
+ 
+
+    /**
+     * Get the artifact id from the dependencies of the project
+     * @param groupId The group id 
+     * @param artifactId The artifact id
+     * @return The artifact id or {@code null}
+     * @throws MojoExecutionException On error
+     */
+    ArtifactId getArtifactIdFromDependencies(final String groupId, final String artifactId) 
+    throws MojoExecutionException {
+        final List<Dependency> allDependencies = new ArrayList<>();
+        
+        if (project.getDependencies() != null) {
+            allDependencies.addAll(project.getDependencies());
+        }
+        if (project.getDependencyManagement() != null && project.getDependencyManagement().getDependencies() != null ) {
+            allDependencies.addAll(project.getDependencyManagement().getDependencies());
+        }
+
+        for (final Dependency d : allDependencies) {
+            if (groupId.equals(d.getGroupId()) &&
+                    artifactId.equals(d.getArtifactId())) {
+
+                return new ArtifactId(d.getGroupId(), d.getArtifactId(), d.getVersion(), d.getClassifier(), d.getType());
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Find the latest version for the dependency
+     * @param dependency The dependency to check
+     * @return The latest version or {code null}
+     * @throws MojoExecutionException If something goes wrong
+     */
+    String getLatestVersion(final Dependency dependency) throws MojoExecutionException {
+        final VersionsHelper helper = new DefaultVersionsHelper(artifactFactory, artifactResolver, artifactMetadataSource,
+                remoteArtifactRepositories, null, localRepository, null, null, null,
+                null, this.log, this.mavenSession, null);
+        try {
+            final Map<Dependency, ArtifactVersions> updateInfos = helper.lookupDependenciesUpdates(Collections.singleton(dependency), false);
+
+            final Map<Dependency, String> result = new HashMap<>();
+
+            for (final Map.Entry<Dependency, ArtifactVersions> entry : updateInfos.entrySet()) {
+                UpdateScope scope = UpdateScope.ANY;
+                final String versionInfo = entry.getKey().getSystemPath();
+                String newVersion = null;
+                if (versionInfo != null && !versionInfo.trim().isEmpty()) {
+                    scope = getScope(versionInfo);
+                    if (scope == null) {
+                        this.log.debug("Using provided version " + versionInfo + " for " + entry.getKey());
+                        newVersion = versionInfo;
+                    }
+                }
+                if (newVersion == null) {
+                    newVersion = getVersion(entry, scope);
+                    this.log.debug("Detected new version " + newVersion + " using scope " + scope.toString() + " for "
+                            + entry.getKey());
+    
+                }
+                if (newVersion != null) {
+                    result.put(entry.getKey(), newVersion);
+                }
+            }
+    
+            return result.get(dependency);
+    
+        } catch (ArtifactMetadataRetrievalException
+                | InvalidVersionSpecificationException e) {
+            throw new MojoExecutionException("Unable to calculate updates", e);
+        }
+    }
+
+    /**
+     * Get the latest version
+     * @param entry The result
+     * @param scope The scope to use
+     * @return The latest version
+     */
+    private String getVersion(final Map.Entry<Dependency, ArtifactVersions> entry, final UpdateScope scope) {
+        ArtifactVersion latest;
+        if (entry.getValue().isCurrentVersionDefined()) {
+            latest = entry.getValue().getNewestUpdate(scope, false);
+        } else {
+            ArtifactVersion newestVersion = entry.getValue()
+                    .getNewestVersion(entry.getValue().getArtifact().getVersionRange(), false);
+            latest = newestVersion == null ? null
+                    : entry.getValue().getNewestUpdate(newestVersion, scope, false);
+            if (latest != null
+                    && ArtifactVersions.isVersionInRange(latest, entry.getValue().getArtifact().getVersionRange())) {
+                latest = null;
+            }
+        }
+        return latest != null ? latest.toString() : null;
+    }
+
+    /**
+     * Get the scope from the version info
+     * @param versionInfo The info
+     * @return The scope
+     */
+    private UpdateScope getScope(final String versionInfo) {
+        final UpdateScope scope;
+        if (versionInfo == null || "ANY".equalsIgnoreCase(versionInfo)) {
+            scope = UpdateScope.ANY;
+        } else if ("MAJOR".equalsIgnoreCase(versionInfo)) {
+            scope = UpdateScope.MAJOR;
+        } else if ("MINOR".equalsIgnoreCase(versionInfo)) {
+            scope = UpdateScope.MINOR;
+        } else if ("INCREMENTAL".equalsIgnoreCase(versionInfo)) {
+            scope = UpdateScope.INCREMENTAL;
+        } else if ("SUBINCREMENTAL".equalsIgnoreCase(versionInfo)) {
+            scope = UpdateScope.SUBINCREMENTAL;
+        } else {
+            scope = null;
+        }
+        return scope;
+    }
+}

--- a/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/AemAnalyseMojoTest.java
+++ b/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/AemAnalyseMojoTest.java
@@ -20,8 +20,11 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Build;
@@ -101,16 +104,8 @@ public class AemAnalyseMojoTest {
         assertEquals(def456.toUri().toURL(), url2);
     }
 
-    @Test(expected = MojoExecutionException.class)
-    public void testGetSDKFromDependencies() throws Exception {
-        MavenProject prj = Mockito.mock(MavenProject.class);
-        AemAnalyseMojo mojo = new TestAnalyseMojo(prj);
-
-        mojo.getSDKFromDependencies("com.adobe.aem", "aem-sdk-api", true);
-    }
-
     @Test
-    public void testGetSDKFromDependencies2() throws Exception {
+    public void testGetArtifactIdFromDependencies2() throws Exception {
         Dependency dep = new Dependency();
         Dependency sdkDep = new Dependency();
         sdkDep.setGroupId("com.adobe.aem");
@@ -127,11 +122,11 @@ public class AemAnalyseMojoTest {
         AemAnalyseMojo mojo = new TestAnalyseMojo(prj);
 
         assertEquals(new ArtifactId(sdkDep.getGroupId(), sdkDep.getArtifactId(), sdkDep.getVersion(), sdkDep.getClassifier(), sdkDep.getType()), 
-                mojo.getSDKFromDependencies("com.adobe.aem", "aem-sdk-api", true));
+                mojo.getArtifactIdFromDependencies("com.adobe.aem", "aem-sdk-api"));
     }
 
     @Test
-    public void testGetSDKFromDedpendencies2() throws Exception {
+    public void testDiscoverAddons() throws Exception {
         Dependency dep = new Dependency();
         Dependency sdkDep = new Dependency();
         sdkDep.setGroupId("com.adobe.aem");
@@ -153,9 +148,35 @@ public class AemAnalyseMojoTest {
                 addons.get(0));
     }
     
+    @Test
+    public void testGetSDKArtifactIdWithConfiguredVersionAndArtifactId() throws Exception {
+        final MavenProject prj = Mockito.mock(MavenProject.class);
+        final AemAnalyseMojo mojo = new TestAnalyseMojo(prj);
+        mojo.sdkArtifactId = "my-artifact";
+        mojo.sdkVersion = "5.0";
+
+        final ArtifactId id = mojo.getSDKArtifactId();
+        assertEquals(Constants.SDK_GROUP_ID, id.getGroupId());
+        assertEquals("my-artifact", id.getArtifactId());
+        assertEquals("5.0", id.getVersion());
+    }
+
+    @Test(expected = MojoExecutionException.class)
+    public void testGetSDKArtifactIdWithoutDependency() throws Exception {
+        final MavenProject prj = Mockito.mock(MavenProject.class);
+        final AemAnalyseMojo mojo = new TestAnalyseMojo(prj);
+        mojo.sdkArtifactId = Constants.SDK_ARTIFACT_ID;
+
+        mojo.getSDKArtifactId();
+    }
+
     private static class TestAnalyseMojo extends AemAnalyseMojo {
-        private TestAnalyseMojo(MavenProject prj) {
-            project = prj;
+        private TestAnalyseMojo(final MavenProject prj) {
+            this.project = prj;
+        }
+
+        String getLatestVersion(final Dependency dependencies) throws MojoExecutionException {
+            return null;
         }
     }
 }

--- a/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/AemAnalyseMojoTest.java
+++ b/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/AemAnalyseMojoTest.java
@@ -20,17 +20,11 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.model.Build;
-import org.apache.maven.model.Dependency;
-import org.apache.maven.model.DependencyManagement;
-import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
 import org.apache.sling.feature.ArtifactId;
 import org.apache.sling.feature.builder.ArtifactProvider;
@@ -104,79 +98,9 @@ public class AemAnalyseMojoTest {
         assertEquals(def456.toUri().toURL(), url2);
     }
 
-    @Test
-    public void testGetArtifactIdFromDependencies2() throws Exception {
-        Dependency dep = new Dependency();
-        Dependency sdkDep = new Dependency();
-        sdkDep.setGroupId("com.adobe.aem");
-        sdkDep.setArtifactId("aem-sdk-api");
-        sdkDep.setVersion("1.3.5");
-
-        DependencyManagement depMgmt = new DependencyManagement();
-        depMgmt.addDependency(dep);
-        depMgmt.addDependency(sdkDep);
-
-        MavenProject prj = Mockito.mock(MavenProject.class);
-        Mockito.when(prj.getDependencyManagement()).thenReturn(depMgmt);
-
-        AemAnalyseMojo mojo = new TestAnalyseMojo(prj);
-
-        assertEquals(new ArtifactId(sdkDep.getGroupId(), sdkDep.getArtifactId(), sdkDep.getVersion(), sdkDep.getClassifier(), sdkDep.getType()), 
-                mojo.getArtifactIdFromDependencies("com.adobe.aem", "aem-sdk-api"));
-    }
-
-    @Test
-    public void testDiscoverAddons() throws Exception {
-        Dependency dep = new Dependency();
-        Dependency sdkDep = new Dependency();
-        sdkDep.setGroupId("com.adobe.aem");
-        sdkDep.setArtifactId("aem-cif-sdk-api");
-        sdkDep.setClassifier("aem-cif-sdk");
-        sdkDep.setVersion("1.3.2");
-
-        DependencyManagement depMgmt = new DependencyManagement();
-        depMgmt.addDependency(dep);
-        depMgmt.addDependency(sdkDep);
-
-        MavenProject prj = Mockito.mock(MavenProject.class);
-        Mockito.when(prj.getDependencyManagement()).thenReturn(depMgmt);
-
-        AemAnalyseMojo mojo = new TestAnalyseMojo(prj);
-        final List<ArtifactId> addons = mojo.discoverAddons(null);
-        assertEquals(1, addons.size());
-        assertEquals(new ArtifactId(sdkDep.getGroupId(), sdkDep.getArtifactId(), sdkDep.getVersion(), sdkDep.getClassifier(), sdkDep.getType()), 
-                addons.get(0));
-    }
-    
-    @Test
-    public void testGetSDKArtifactIdWithConfiguredVersionAndArtifactId() throws Exception {
-        final MavenProject prj = Mockito.mock(MavenProject.class);
-        final AemAnalyseMojo mojo = new TestAnalyseMojo(prj);
-        mojo.sdkArtifactId = "my-artifact";
-        mojo.sdkVersion = "5.0";
-
-        final ArtifactId id = mojo.getSDKArtifactId();
-        assertEquals(Constants.SDK_GROUP_ID, id.getGroupId());
-        assertEquals("my-artifact", id.getArtifactId());
-        assertEquals("5.0", id.getVersion());
-    }
-
-    @Test(expected = MojoExecutionException.class)
-    public void testGetSDKArtifactIdWithoutDependency() throws Exception {
-        final MavenProject prj = Mockito.mock(MavenProject.class);
-        final AemAnalyseMojo mojo = new TestAnalyseMojo(prj);
-        mojo.sdkArtifactId = Constants.SDK_ARTIFACT_ID;
-
-        mojo.getSDKArtifactId();
-    }
-
     private static class TestAnalyseMojo extends AemAnalyseMojo {
         private TestAnalyseMojo(final MavenProject prj) {
             this.project = prj;
-        }
-
-        String getLatestVersion(final Dependency dependencies) throws MojoExecutionException {
-            return null;
         }
     }
 }

--- a/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/VersionUtilTest.java
+++ b/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/VersionUtilTest.java
@@ -92,7 +92,7 @@ public class VersionUtilTest {
 
     private static class TestVersionUtil extends VersionUtil {
         private TestVersionUtil(final MavenProject prj) {
-            super(Mockito.mock(Log.class), prj, null, null, null, null, null, null);
+            super(Mockito.mock(Log.class), prj, null, null, null, null);
         }
 
         String getLatestVersion(final Dependency dependencies) throws MojoExecutionException {

--- a/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/VersionUtilTest.java
+++ b/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/VersionUtilTest.java
@@ -1,0 +1,102 @@
+/*
+  Copyright 2020 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.aem.analyser.mojos;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
+import org.apache.maven.model.Dependency;
+import org.apache.maven.model.DependencyManagement;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.apache.sling.feature.ArtifactId;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class VersionUtilTest {
+
+    @Test
+    public void testGetArtifactIdFromDependencies() throws Exception {
+        Dependency dep = new Dependency();
+        Dependency sdkDep = new Dependency();
+        sdkDep.setGroupId("com.adobe.aem");
+        sdkDep.setArtifactId("aem-sdk-api");
+        sdkDep.setVersion("1.3.5");
+
+        DependencyManagement depMgmt = new DependencyManagement();
+        depMgmt.addDependency(dep);
+        depMgmt.addDependency(sdkDep);
+
+        MavenProject prj = Mockito.mock(MavenProject.class);
+        Mockito.when(prj.getDependencyManagement()).thenReturn(depMgmt);
+
+        final VersionUtil util = new TestVersionUtil(prj);
+
+        assertEquals(new ArtifactId(sdkDep.getGroupId(), sdkDep.getArtifactId(), sdkDep.getVersion(), sdkDep.getClassifier(), sdkDep.getType()), 
+                util.getArtifactIdFromDependencies("com.adobe.aem", "aem-sdk-api"));
+    }
+
+    @Test
+    public void testDiscoverAddons() throws Exception {
+        Dependency dep = new Dependency();
+        Dependency sdkDep = new Dependency();
+        sdkDep.setGroupId("com.adobe.aem");
+        sdkDep.setArtifactId("aem-cif-sdk-api");
+        sdkDep.setClassifier("aem-cif-sdk");
+        sdkDep.setVersion("1.3.2");
+
+        DependencyManagement depMgmt = new DependencyManagement();
+        depMgmt.addDependency(dep);
+        depMgmt.addDependency(sdkDep);
+
+        MavenProject prj = Mockito.mock(MavenProject.class);
+        Mockito.when(prj.getDependencyManagement()).thenReturn(depMgmt);
+
+        final VersionUtil util = new TestVersionUtil(prj);
+        final List<ArtifactId> addons = util.discoverAddons(null, true);
+        assertEquals(1, addons.size());
+        assertEquals(new ArtifactId(sdkDep.getGroupId(), sdkDep.getArtifactId(), sdkDep.getVersion(), sdkDep.getClassifier(), sdkDep.getType()), 
+                addons.get(0));
+    }
+    
+    @Test
+    public void testGetSDKArtifactIdWithConfiguredVersionAndArtifactId() throws Exception {
+        final MavenProject prj = Mockito.mock(MavenProject.class);
+        final VersionUtil util = new TestVersionUtil(prj);
+
+        final ArtifactId id = util.getSDKArtifactId("my-artifact", "5.0", false);
+        assertEquals(Constants.SDK_GROUP_ID, id.getGroupId());
+        assertEquals("my-artifact", id.getArtifactId());
+        assertEquals("5.0", id.getVersion());
+    }
+
+    @Test(expected = MojoExecutionException.class)
+    public void testGetSDKArtifactIdWithoutDependency() throws Exception {
+        final MavenProject prj = Mockito.mock(MavenProject.class);
+        final VersionUtil util = new TestVersionUtil(prj);
+
+        util.getSDKArtifactId(Constants.SDK_ARTIFACT_ID, null, false);
+    }
+
+    private static class TestVersionUtil extends VersionUtil {
+        private TestVersionUtil(final MavenProject prj) {
+            super(Mockito.mock(Log.class), prj, null, null, null, null, null, null);
+        }
+
+        String getLatestVersion(final Dependency dependencies) throws MojoExecutionException {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
WIth this PR the plugin uses the latest version for the SDK and the add-ons - unless an SDK version is explicitely configured.
The sdkGroupId configuration is removed, as the group id is fixed. I left the sdkArtifactId as we will need that in the future.


- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
