### PR TITLE
Enable analyser about deprecated api usage #50

### DIFF
--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/AemAnalyser.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/AemAnalyser.java
@@ -42,7 +42,8 @@ public class AemAnalyser {
     + "api-regions-crossfeature-dups,"
     + "api-regions-exportsimports,"
 //        + "repoinit," disable until SLING-10215 is fixed
-    + "configuration-api";
+    + "configuration-api,"
+    + "region-deprecated-api";
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
@@ -77,7 +77,7 @@ public class AemAnalyseMojo extends AbstractMojo {
      * Use dependency versions. If this is enabled, the version for the SDK and the Add-ons is taken
      * from the project dependencies. By default, the latest version is used.
      */
-    @Parameter(required = false, defaultValue = "false")
+    @Parameter(required = false, defaultValue = "false", property = "sdkUseDependency")
     boolean useDependencyVersions;
 
     /**


### PR DESCRIPTION
This closes #50

This adds the new analyser to the list of default analysers

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
