### PR TITLE
add transitive dependencies of cpconverter

### DIFF
--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -277,7 +277,6 @@ governing permissions and limitations under the License.
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.commons.osgi</artifactId>
       <version>2.3.0</version>
-      <scope>provided</scope>
      </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>

--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -103,33 +103,12 @@ governing permissions and limitations under the License.
       <artifactId>maven-artifact</artifactId>
       <version>${maven.version}</version>
     </dependency>
-    <!-- Plexus is currently needed for cpconverter -->
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-archiver</artifactId>
-      <version>4.2.5</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-utils</artifactId>
-      <version>3.3.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-io</artifactId>
-      <version>3.2.0</version>
-    </dependency>
 
     <!-- Feature Model -->
     <dependency>
       <groupId>org.apache.sling</groupId>
       <artifactId>org.apache.sling.feature</artifactId>
       <version>1.2.22</version>
-    </dependency>
-    <dependency>
-      <groupId>org.osgi</groupId>
-      <artifactId>osgi.core</artifactId>
-      <version>7.0.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.geronimo.specs</groupId>
@@ -154,7 +133,7 @@ governing permissions and limitations under the License.
     <dependency>
       <groupId>org.apache.felix</groupId>
       <artifactId>org.apache.felix.cm.json</artifactId>
-      <version>1.0.6</version>    
+      <version>1.0.6</version>
     </dependency>
     <dependency>
       <groupId>org.osgi</groupId>
@@ -183,8 +162,111 @@ governing permissions and limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.contentparser.api</artifactId>
-      <version>2.0.0</version>
+      <artifactId>org.apache.sling.feature.cpconverter</artifactId>
+      <version>1.1.0</version>
+    </dependency>
+    
+    <!-- START: Transitive but hidden (due to scope "provided") dependencies of cpconverter, update whenever you update cpconverter
+                There is not yet a way to enforce this being complete (https://issues.apache.org/jira/browse/MENFORCER-385)
+     -->
+    <!--declared before
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    -->
+    <!-- not used outside of CLI
+    <dependency>
+      <groupId>info.picocli</groupId>
+      <artifactId>picocli</artifactId>
+      <version>${picocli.version}</version>
+    </dependency>
+    -->
+    <dependency>
+      <groupId>org.apache.jackrabbit.vault</groupId>
+      <artifactId>org.apache.jackrabbit.vault</artifactId>
+      <version>3.4.10</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>jackrabbit-spi-commons</artifactId>
+      <version>2.18.4</version>
+    </dependency>
+    <dependency>
+      <groupId>javax.jcr</groupId>
+      <artifactId>jcr</artifactId>
+      <version>2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.8.0</version>
+    </dependency>
+    <!-- defined before 
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.feature</artifactId>
+      <version>1.2.22</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.feature.extension.apiregions</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.repoinit.parser</artifactId>
+      <version>1.6.8</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.converter</artifactId>
+      <version>1.0.14</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.utils</artifactId>
+      <version>1.11.4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.util.function</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.geronimo.specs</groupId>
+      <artifactId>geronimo-json_1.1_spec</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.johnzon</groupId>
+      <artifactId>johnzon-core</artifactId>
+      <version>1.2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.cm.json</artifactId>
+      <version>1.0.6</version>
+    </dependency>-->
+    <dependency>
+      <groupId>org.osgi</groupId>
+      <artifactId>org.osgi.framework</artifactId>
+      <version>1.9.0</version>
+    </dependency>
+    <!-- defined before 
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.configadmin</artifactId>
+      <version>1.9.16</version>
+    </dependency>-->
+    <dependency>
+      <groupId>org.apache.jackrabbit</groupId>
+      <artifactId>jackrabbit-api</artifactId>
+      <version>2.18.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
@@ -193,15 +275,21 @@ governing permissions and limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.feature.cpconverter</artifactId>
-      <version>1.1.0</version>
-    </dependency>
-    
+      <artifactId>org.apache.sling.commons.osgi</artifactId>
+      <version>2.3.0</version>
+      <scope>provided</scope>
+     </dependency>
     <dependency>
-      <groupId>javax.jcr</groupId>
-      <artifactId>jcr</artifactId>
-      <version>2.0</version>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.contentparser.api</artifactId>
+      <version>2.0.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.contentparser.json</artifactId>
+      <version>2.0.0</version>
+    </dependency>
+    <!-- END: Transitive but hidden (due to scope "provided") dependencies of cpconverter -->
 
     <!-- Test -->
     <dependency>


### PR DESCRIPTION
this is necessary because cpconverter defines those with scope
"provided"
This closes #58

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
