### PR TITLE
Add strict validation mode to turn warnings into errors

### DIFF
--- a/aemanalyser-maven-plugin/README.md
+++ b/aemanalyser-maven-plugin/README.md
@@ -76,8 +76,9 @@ A typical use would be to just configure the **project-analyse** goal if the plu
 
 The plugin can be configured with the following configuration properties:
 
-* **skip** : If this is set to `true` the plugin execution will be skipped. The plugin can also be skipped by setting the propert `aem.analyser.skip` to `true`.
+* **skip** : If this is set to `true` the plugin execution will be skipped. The plugin can also be skipped by setting the property `aem.analyser.skip` to `true`.
 * **failOnAnalyserErrors** : This is by default enabled and causes the build to fail if any analyser reports an error. This can be set to `false` to continue the build.
+* **strictValidation** : If this is set to `true` all warnings from the analyser will be turned in errors and fail the build. The property `aem.analyser.strict` can be used to set this from the commandline.
 * **sdkArtifactId** : By default, the plugin inspects the dependencies of the project and looks for an artifact with the group id `com.adobe.aem` and an artifact id of either `aem-prerelease-sdk-api` or `aem-sdk-api`. For advanced usages, this property can be set to disable the detection mechanism.
 * **sdkVersion** : This property can be used to exactly specify the SDK version to be used for the analysis. If not set, the plugin will use the latest available SDK. The value for this property can also be specified via the command line by setting `sdkVersion`.
 * **useDependencyVersions** : If this property is enabled, the version for the SDK as specified via the dependencies is used. This is by default disabled to use the latest version. The value for this property can also be specified via the command line by setting `sdkUseDependency`.

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
@@ -118,6 +118,13 @@ public class AemAnalyseMojo extends AbstractMojo {
     private String classifier;
 
     /**
+     * If enabled, all analyser warnings will be turned into errors and fail the build.
+     * @since 1.0.12
+     */
+    @Parameter(defaultValue = "false", property = "aem.analyser.strict")
+    private boolean strictValidation;
+
+    /**
      * The maven project
      */
     @Parameter(property = "project", readonly = true, required = true)
@@ -326,17 +333,25 @@ public class AemAnalyseMojo extends AbstractMojo {
             
             // print additional warnings first
             for(final String msg : additionalWarnings) {
-                getLog().warn(msg);
+                if ( strictValidation ) {
+                    getLog().error(msg);
+                } else {
+                    getLog().warn(msg);
+                }
             }
             // now analyser warnings
             for(final String msg : result.getWarnings()) {
-                getLog().warn(msg);
+                if ( strictValidation ) {
+                    getLog().error(msg);
+                } else {
+                    getLog().warn(msg);
+                }
             }
             // finally, analyser errors
             for(final String msg : result.getErrors()) {
                 getLog().error(msg);
             }
-            hasErrors = result.hasErrors();
+            hasErrors = result.hasErrors() || (strictValidation && result.hasWarnings());
 
         } catch ( final Exception e) {
             throw new MojoExecutionException("A fatal error occurred while analysing the features, see error cause:",


### PR DESCRIPTION
Add a configuration to the Maven plugin to enable strict validation

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
