### PR TITLE
Use subcommands in the aemanalyser-cli tool.

### DIFF
--- a/aemanalyser-cli/README.md
+++ b/aemanalyser-cli/README.md
@@ -16,16 +16,29 @@ inside the distro and placed in the lib subdirectory.
 
 ## Usage
 
-For the latest usage information, run the help command of the tool:
+For the latest usage information, run the help option of the tool:
 
 ```
 $ java -jar aemanalyser-cli.jar -h
-Usage: analyse [-hV] [-a=<analysers>]... [-f=<featureFiles>]...
-Execute feature model analysers
+Usage: java -jar analyser.jar [-hV] [COMMAND]
+Execute feature model analyser tool
+  -h, --help      Show this help message and exit.
+  -V, --version   Print version information and exit.
+Commands:
+  analyse  Analyse one or more feature models
+```
+
+Help information on subcommands can be obtained by providing the -h option to the subcommand:
+
+```
+$ java -jar aemanalyser-cli.jar analyse -h
+Usage: java -jar analyser.jar analyse [-hV] [-a=<analysers>]...
+                                      [-f=<featureFiles>]...
+Analyse one or more feature models
   -a, --analyser=<analysers>
                   Analysers to execute
   -f, --features=<featureFiles>
                   Feature files to analyser
   -h, --help      Show this help message and exit.
   -V, --version   Print version information and exit.
-  ```
+```

--- a/aemanalyser-cli/pom.xml
+++ b/aemanalyser-cli/pom.xml
@@ -41,8 +41,11 @@ governing permissions and limitations under the License.
         <version>3.2.0</version>
         <executions>
           <execution>
-            <phase>prepare-package</phase>
-            <goals><goal>copy-dependencies</goal></goals>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+              <goal>build-classpath</goal>
+            </goals>
             <configuration>
               <includeArtifactIds>
                 aemanalyser-core,
@@ -61,9 +64,55 @@ governing permissions and limitations under the License.
                 slf4j-simple
               </includeArtifactIds>
               <outputDirectory>${project.build.directory}/lib</outputDirectory>              
+
+              <!-- These properties are for build-classpath. It creates a classpath for the copied
+                   dependencies and puts it in the ${distro.classpath} property. The jar Class-Path
+                   uses spaces as separators. Unfortunately <pathSeparator> configuration property
+                   does not work with a space as value, so the pathSeparator is set to a character
+                   here and this is then replaced later using the regex-property plugin. -->
+              <prefix>lib</prefix>
+              <outputProperty>distro.classpath</outputProperty>
+              <pathSeparator>:</pathSeparator>
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>3.2.0</version>
+        <executions>
+          <execution>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <!-- Here the value of property for the jar the Class-Path is replaced to have a space
+                   as separator. Unfortunately <replacement> does not work if a single space if specified
+                   so this uses the surrounding .jar and lib to provide some content. -->
+              <name>distro.classpath.replaced</name>
+              <value>${distro.classpath}</value>
+              <regex>[.]jar[:]lib</regex>
+              <replacement>.jar lib</replacement>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.2.0</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>com.adobe.aem.analyser.cli.Main</mainClass>
+            </manifest>
+            <manifestEntries>
+              <!-- Include the computed classpath with all copied dependencies in the jar here -->
+              <Class-Path>${distro.classpath.replaced}</Class-Path>
+            </manifestEntries>
+          </archive>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
@@ -79,22 +128,7 @@ governing permissions and limitations under the License.
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.2.0</version>
-        <configuration>
-          <archive>
-            <manifest>
-              <!-- TODO this includes too much, which is harmless but ugly, clean up -->
-              <addClasspath>true</addClasspath>
-              <classpathPrefix>lib</classpathPrefix>
-              <mainClass>com.adobe.aem.analyser.cli.Analyse</mainClass>
-            </manifest>
-          </archive>
-        </configuration>
-      </plugin>
-    
+      </plugin>    
     </plugins>
   </build>
   

--- a/aemanalyser-cli/src/main/java/com/adobe/aem/analyser/cli/Analyse.java
+++ b/aemanalyser-cli/src/main/java/com/adobe/aem/analyser/cli/Analyse.java
@@ -26,12 +26,11 @@ import org.apache.sling.feature.io.json.FeatureJSONReader;
 import com.adobe.aem.analyser.AemAnalyser;
 import com.adobe.aem.analyser.AemAnalyserResult;
 
-import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 @Command(name = "analyse", mixinStandardHelpOptions =  true,
-    description = "Execute feature model analysers",
+    description = "Analyse one or more feature models",
     versionProvider = VersionProvider.class)
 public class Analyse implements Callable<Integer> {
     @Option(names = {"-f", "--features"}, description = "Feature files to analyser")
@@ -68,10 +67,5 @@ public class Analyse implements Callable<Integer> {
         }
 
         return result.hasErrors() ? 1 : 0;
-    }
-
-    public static void main(String[] args) {
-        int exitCode = new CommandLine(new Analyse()).execute(args);
-        System.exit(exitCode);
     }
 }

--- a/aemanalyser-cli/src/main/java/com/adobe/aem/analyser/cli/Main.java
+++ b/aemanalyser-cli/src/main/java/com/adobe/aem/analyser/cli/Main.java
@@ -1,0 +1,26 @@
+/*
+  Copyright 2021 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser.cli;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+
+@Command(name = "java -jar aemanalyser-cli.jar", mixinStandardHelpOptions =  true,
+    description = "Execute feature model analyser tool",
+    subcommands = Analyse.class,
+    versionProvider = VersionProvider.class)
+public class Main {
+    public static void main(String[] args) {
+        int exitCode = new CommandLine(new Main()).execute(args);
+        System.exit(exitCode);
+    }
+}


### PR DESCRIPTION
Currently only one subcommand is defined: 'analyse'. Others can come
later.
This change also contains a fix for the building of the aemanalyser-cli
jar file to not have dependencies in the Class-Path that are not needed
to run the tool (Maven automatically put all transitive dependencies in
there).
