### PR TITLE
Add interpolation support for configurations

### DIFF
--- a/aemanalyser-cli/pom.xml
+++ b/aemanalyser-cli/pom.xml
@@ -52,10 +52,12 @@ governing permissions and limitations under the License.
                 geronimo-json_1.1_spec,
                 johnzon-core,
                 org.apache.felix.cm.json,
+                org.apache.felix.configadmin.plugin.interpolation,
                 org.apache.felix.converter,
                 org.apache.sling.feature,
                 org.apache.sling.feature.analyser,
                 org.apache.sling.feature.extension.apiregions,
+                org.osgi.service.cm,
                 org.osgi.framework,
                 org.osgi.resource,
                 org.osgi.util.function,
@@ -138,7 +140,21 @@ governing permissions and limitations under the License.
       <artifactId>aemanalyser-core</artifactId>
       <version>0.0.1-SNAPSHOT</version>
     </dependency>
-  
+
+    <!-- 
+     Interpolation
+     -->    
+    <dependency>
+      <groupId>org.apache.felix</groupId>
+      <artifactId>org.apache.felix.configadmin.plugin.interpolation</artifactId>
+      <version>1.2.0-SNAPSHOT</version>    
+    </dependency>
+    <dependency>
+       <groupId>org.osgi</groupId>
+       <artifactId>org.osgi.service.cm</artifactId>
+       <version>1.6.0</version>
+    </dependency>
+
     <!--
      | CLI
     -->

--- a/aemanalyser-cli/src/test/java/com/adobe/aem/analyser/cli/AnalyseTest.java
+++ b/aemanalyser-cli/src/test/java/com/adobe/aem/analyser/cli/AnalyseTest.java
@@ -1,0 +1,48 @@
+/*
+  Copyright 2021 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser.cli;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Configuration;
+import org.apache.sling.feature.Configurations;
+import org.apache.sling.feature.Feature;
+import org.junit.Test;
+
+public class AnalyseTest {
+    @Test
+    public void testInterpolatePlaceholders() {
+        Analyse a = new Analyse();
+
+        Feature f = new Feature(ArtifactId.fromMvnId("g:a:1"));
+        Configurations configs = f.getConfigurations();
+
+        Configuration cfg = new Configuration("org.foo.pid");
+        cfg.getProperties().put("abc", "def");
+        cfg.getProperties().put("propvar", "my$[prop:some.prop]val");
+        configs.add(cfg);
+
+        f.getFrameworkProperties().put("some.prop", "999");
+        f.getFrameworkProperties().put("some.other.prop", "888");
+
+        a.interpolatePlaceholders(Collections.singletonList(f));
+
+        Configuration procCfg = f.getConfigurations().getConfiguration("org.foo.pid");
+        assertEquals("def", procCfg.getConfigurationProperties().get("abc"));
+        assertEquals("my999val", procCfg.getConfigurationProperties().get("propvar"));
+        assertEquals("def", procCfg.getProperties().get("abc"));
+        assertEquals("my999val", procCfg.getProperties().get("propvar"));
+    }
+}

--- a/aemanalyser-core/pom.xml
+++ b/aemanalyser-core/pom.xml
@@ -61,6 +61,13 @@ governing permissions and limitations under the License.
       <version>1.3.28</version>
     </dependency>
 
+    <!-- Feature Model API Regions Extension -->
+    <dependency>
+      <groupId>org.apache.sling</groupId>
+      <artifactId>org.apache.sling.feature.extension.apiregions</artifactId>
+      <version>1.3.8</version>
+    </dependency>
+
     <!-- Content Package to Feature Model Converter-->
     <dependency>
       <groupId>org.apache.sling</groupId>

--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -199,13 +199,6 @@ governing permissions and limitations under the License.
       <version>2.18.4</version>
     </dependency>
 
-    <!-- Feature Model API Regions Extension -->
-    <dependency>
-      <groupId>org.apache.sling</groupId>
-      <artifactId>org.apache.sling.feature.extension.apiregions</artifactId>
-      <version>1.3.8</version>
-    </dependency>
-
     <!-- Content Package to Feature Model Converter-->
     <dependency>
       <groupId>org.apache.sling</groupId>


### PR DESCRIPTION
## Description

Interpolation support allows configuration values with placeholders as supported by the Apache Felix Configuration Interpolation plugin to be substituted before the analysis is run.
To enable this interpolation pass in the `-i` command-line flag.
To support substitution of secrets (marked with a `$[secret:somesecret]` placeholder), provide the location(s) of the secrets on the file system with the `-s` command-line flag.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
