### PR TITLE
Make the bundles output directory configurable

### DIFF
--- a/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemPackageConverter.java
+++ b/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemPackageConverter.java
@@ -18,8 +18,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.sling.feature.cpconverter.ContentPackage2FeatureModelConverter;
-import org.apache.sling.feature.cpconverter.ConverterException;
 import org.apache.sling.feature.cpconverter.ContentPackage2FeatureModelConverter.SlingInitialContentPolicy;
+import org.apache.sling.feature.cpconverter.ConverterException;
 import org.apache.sling.feature.cpconverter.accesscontrol.AclManager;
 import org.apache.sling.feature.cpconverter.accesscontrol.DefaultAclManager;
 import org.apache.sling.feature.cpconverter.artifacts.LocalMavenRepositoryArtifactsDeployer;
@@ -40,6 +40,8 @@ public class AemPackageConverter {
 
     private File featureOutputDirectory;
 
+    private File bundlesOutputDirectory;
+
     private File converterOutputDirectory;
 
     private String artifactIdOverride;
@@ -56,6 +58,20 @@ public class AemPackageConverter {
      */
     public void setFeatureOutputDirectory(File featureOutputDirectory) {
         this.featureOutputDirectory = featureOutputDirectory;
+    }
+
+    /**
+     * @return the bundlesOutputDirectory
+     */
+    public File getBundlesOutputDirectory() {
+        return bundlesOutputDirectory;
+    }
+
+    /**
+     * @param bundlesOutputDirectory the featureOutputDirectory to set
+     */
+    public void setBundlesOutputDirectory(File bundlesOutputDirectory) {
+        this.bundlesOutputDirectory = bundlesOutputDirectory;
     }
 
     /**
@@ -102,12 +118,14 @@ public class AemPackageConverter {
 
         featuresManager.setExportToAPIRegion("global");
 
+        File bundlesOutputDir = this.bundlesOutputDirectory != null
+                ? this.bundlesOutputDirectory : this.converterOutputDirectory;
         ContentPackage2FeatureModelConverter converter = new ContentPackage2FeatureModelConverter(false,
                 SlingInitialContentPolicy.KEEP)
                 .setFeaturesManager(featuresManager)
                 .setBundlesDeployer(
                         new LocalMavenRepositoryArtifactsDeployer(
-                            this.converterOutputDirectory
+                            bundlesOutputDir
                         )
                     )
                     .setEntryHandlersManager(


### PR DESCRIPTION
## Description

Make the bundles output directory configurable

## Related Issue

#105

## How Has This Been Tested?

- `mvn clean install`
- configure the bundles directory in a downstream project

## Screenshots (if appropriate):

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

This is non-breaking since the bundles output directory defaults to the previous value if not set.

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All ~new~ and existing tests passed.
