### PR TITLE
Add analyser to check usage of env vars

### DIFF
--- a/aemanalyser-core/pom.xml
+++ b/aemanalyser-core/pom.xml
@@ -75,11 +75,23 @@ governing permissions and limitations under the License.
       <version>1.1.10</version>
     </dependency>
 
+    <dependency>
+        <groupId>org.apache.felix</groupId>
+        <artifactId>org.apache.felix.configadmin.plugin.interpolation</artifactId>
+        <version>1.2.0</version>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.13.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/aemanalyser-core/pom.xml
+++ b/aemanalyser-core/pom.xml
@@ -78,7 +78,7 @@ governing permissions and limitations under the License.
     <dependency>
         <groupId>org.apache.felix</groupId>
         <artifactId>org.apache.felix.configadmin.plugin.interpolation</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.2</version>
     </dependency>
 
     <!-- Test -->

--- a/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemAggregator.java
+++ b/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemAggregator.java
@@ -101,7 +101,7 @@ public class AemAggregator {
      *
      * @param artifactsDeployer the artifactsDeployer to set
      */
-    public void setArtifactsDeployer(ArtifactsDeployer artifactsDeployer) {
+    public void setArtifactsDeployer(final ArtifactsDeployer artifactsDeployer) {
         this.artifactsDeployer = artifactsDeployer;
     }
 
@@ -115,7 +115,7 @@ public class AemAggregator {
     /**
      * @param featureProvider the featureProvider to set
      */
-    public void setFeatureProvider(FeatureProvider featureProvider) {
+    public void setFeatureProvider(final FeatureProvider featureProvider) {
         this.featureProvider = featureProvider;
     }
 
@@ -129,7 +129,7 @@ public class AemAggregator {
     /**
      * @param projectId the projectId to set
      */
-    public void setProjectId(ArtifactId projectId) {
+    public void setProjectId(final ArtifactId projectId) {
         this.projectId = projectId;
     }
 
@@ -143,7 +143,7 @@ public class AemAggregator {
     /**
      * @param featureOutputDirectory the featureOutputDirectory to set
      */
-    public void setFeatureOutputDirectory(File featureOutputDirectory) {
+    public void setFeatureOutputDirectory(final File featureOutputDirectory) {
         this.featureOutputDirectory = featureOutputDirectory;
     }
 
@@ -193,7 +193,7 @@ public class AemAggregator {
         // Produce the user aggregates
         final Map<String, List<Feature>> userAggregates = getUserAggregates(projectFeatures);
 
-        this.aggregate(userAggregates, Mode.USER, projectFeatures);
+        final List<Feature> userResult = this.aggregate(userAggregates, Mode.USER, projectFeatures);
 
         // Produce the product aggregates
         final Map<String, List<Feature>> productAggregates = getProductAggregates();
@@ -203,7 +203,12 @@ public class AemAggregator {
         // Produce the final aggregates
         final Map<String, List<Feature>> finalAggregates = getFinalAggregates(userAggregates, projectFeatures);
 
-        return this.aggregate(finalAggregates, Mode.FINAL, projectFeatures);
+        final List<Feature> finalResult = this.aggregate(finalAggregates, Mode.FINAL, projectFeatures);
+
+        final List<Feature> result = new ArrayList<>();
+        result.addAll(userResult);
+        result.addAll(finalResult);
+        return result;
     }
 
     private Map<String, Feature> readFeatures() throws IOException {

--- a/aemanalyser-core/src/main/java/com/adobe/aem/analyser/impl/EnvVarAnalyserTask.java
+++ b/aemanalyser-core/src/main/java/com/adobe/aem/analyser/impl/EnvVarAnalyserTask.java
@@ -1,0 +1,103 @@
+/*
+  Copyright 2021 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser.impl;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Dictionary;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.felix.configadmin.plugin.interpolation.Interpolator;
+import org.apache.felix.configadmin.plugin.interpolation.Interpolator.Provider;
+import org.apache.sling.feature.Configuration;
+import org.apache.sling.feature.analyser.task.AnalyserTask;
+import org.apache.sling.feature.analyser.task.AnalyserTaskContext;
+
+public class EnvVarAnalyserTask implements AnalyserTask {
+
+    private static final String TYPE_ENV = "env";
+
+    private static final List<String> PREFIXES = Arrays.asList("INTERNAL_", "ADOBE_");
+
+    @Override
+    public String getId() {
+        return "aem-env-var";
+    }
+
+    @Override
+    public String getName() {
+        return "AEM Env Var Analyser";
+    }
+
+    @Override
+    public void execute(final AnalyserTaskContext context) throws Exception {
+        for(final Configuration cfg : context.getFeature().getConfigurations()) {
+            check(context, cfg);
+        }
+    }
+    
+    /**
+     * Check if a configuration is using unwanted prefixes in env vars.
+     * @param context The context
+     * @param cfg The configuration
+     */
+    private void check(final AnalyserTaskContext context, final Configuration cfg) {
+        final Dictionary<String, Object> properties = cfg.getConfigurationProperties();
+        for(final String propName : Collections.list(properties.keys())) {
+            final Object value = properties.get(propName);
+            boolean valid = true;
+            if (value instanceof String) {
+                valid = checkValue(value.toString());
+            } else if (value instanceof String[]) {
+                final String[] array = (String[]) value;
+                for(final String val : array) {
+                    if ( !checkValue(val) ) {
+                        valid = false;
+                        break;
+                    };
+                }
+            }
+           
+            if ( !valid ) {
+                context.reportConfigurationError(cfg, "Value for property '" + propName 
+                    + "' must not use env vars prefixed with INTERNAL_ or ADOBE_");
+            }
+        }
+    }
+
+    /**
+     * Check if a value is using unwanted prefixes.
+     * @param context The context
+     * @param cfg The configuration
+     */
+    private boolean checkValue(final String value) {
+        final AtomicBoolean result = new AtomicBoolean(true);
+        Interpolator.replace(value, new Provider() {
+
+            @Override
+            public Object provide(final String type, final String name, final Map<String, String> directives) {
+                if ( TYPE_ENV.equals(type) ) {
+                    for(final String prefix : PREFIXES) {
+                        if ( name.startsWith(prefix) ) {
+                            result.set(false);
+                        }
+                    }
+                }
+                return "";
+            }
+            
+        });
+        return result.get();
+    }
+}

--- a/aemanalyser-core/src/main/resources/META-INF/services/org.apache.sling.feature.analyser.task.AnalyserTask
+++ b/aemanalyser-core/src/main/resources/META-INF/services/org.apache.sling.feature.analyser.task.AnalyserTask
@@ -1,0 +1,1 @@
+com.adobe.aem.analyser.impl.EnvVarAnalyserTask

--- a/aemanalyser-core/src/test/java/com/adobe/aem/analyser/AemAnalyserTest.java
+++ b/aemanalyser-core/src/test/java/com/adobe/aem/analyser/AemAnalyserTest.java
@@ -32,6 +32,15 @@ public class AemAnalyserTest {
         }
     }
 
+    @Test public void testUserIncludedTasks() {
+        final AemAnalyser analyser = new AemAnalyser();
+        assertNotNull(analyser.getIncludedUserTasks());
+        assertEquals(AemAnalyser.DEFAULT_USER_TASKS.split(",").length, analyser.getIncludedUserTasks().size());
+        for(final String t : AemAnalyser.DEFAULT_USER_TASKS.split(",")) {
+            assertTrue(analyser.getIncludedUserTasks().contains(t));
+        }
+    }
+
     @Test public void testDefaultTaskConfigurations() {
         final AemAnalyser analyser = new AemAnalyser();
         assertNotNull(analyser.getTaskConfigurations());
@@ -95,5 +104,13 @@ public class AemAnalyserTest {
 
         assertEquals(1, analyser.getIncludedTasks().size());
         assertTrue(analyser.getIncludedTasks().contains("mytask"));
+    }
+
+    @Test public void testSetIncludedUserTasks() throws Exception {
+        final AemAnalyser analyser = new AemAnalyser();
+        analyser.setIncludedUserTasks(Collections.singleton("mytask"));
+
+        assertEquals(1, analyser.getIncludedUserTasks().size());
+        assertTrue(analyser.getIncludedUserTasks().contains("mytask"));
     }
 }

--- a/aemanalyser-core/src/test/java/com/adobe/aem/analyser/impl/EnvVarAnalyserTaskTest.java
+++ b/aemanalyser-core/src/test/java/com/adobe/aem/analyser/impl/EnvVarAnalyserTaskTest.java
@@ -1,0 +1,58 @@
+/*
+  Copyright 2021 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Configuration;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.analyser.task.AnalyserTask;
+import org.apache.sling.feature.analyser.task.AnalyserTaskContext;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class EnvVarAnalyserTaskTest {
+
+    @Test public void testConstants() {
+        final AnalyserTask task = new EnvVarAnalyserTask();
+        assertEquals("aem-env-var", task.getId());
+        assertEquals("AEM Env Var Analyser", task.getName());
+    }
+
+    @Test public void testAnalyserTask() throws Exception {
+        final AnalyserTaskContext ctx = Mockito.mock(AnalyserTaskContext.class);
+        final Feature f = new Feature(ArtifactId.parse("g:a:1"));
+        Mockito.when(ctx.getFeature()).thenReturn(f);
+
+        final Configuration cfg1 = new Configuration("c1");
+        cfg1.getProperties().put("key1", "$[env:MY_VAR]");
+        cfg1.getProperties().put("key2", "$[env:CONST_AEM_VAR]");
+        f.getConfigurations().add(cfg1);
+
+        final Configuration cfg2 = new Configuration("c2");
+        cfg2.getProperties().put("key", "$[env:INTERNAL_VAR]");
+        f.getConfigurations().add(cfg2);
+
+        final Configuration cfg3 = new Configuration("c3");
+        cfg3.getProperties().put("key", new String[] {"$[env:ADOBE_VAR]"});
+        f.getConfigurations().add(cfg3);
+
+        final AnalyserTask task = new EnvVarAnalyserTask();
+        task.execute(ctx);
+
+        Mockito.verify(ctx).getFeature();
+        Mockito.verify(ctx, Mockito.times(1)).reportConfigurationError(Mockito.eq(cfg2), Mockito.anyString());
+        Mockito.verify(ctx, Mockito.times(1)).reportConfigurationError(Mockito.eq(cfg3), Mockito.anyString());
+        Mockito.verifyNoMoreInteractions(ctx);
+    }
+}

--- a/aemanalyser-maven-plugin/README.md
+++ b/aemanalyser-maven-plugin/README.md
@@ -186,25 +186,24 @@ The following configuration options can be provided to the plugin. However they 
 
 ### Selecting Tasks
 
-The plugin will execute a number of default analysers. It is possible to select a different set of analyser tasks, for example with the following configuration:
+The plugin will execute a number of default analysers. It is possible to select a different set of analyser tasks, for example with the following configuration, the set of analysers running on the final aggregates can be changes.
 
     <analyserTasks>
         <analyserTask>bundle-packages</analyserTask>
         <analyserTask>requirements-capabilities</analyserTask>
     </analyserTasks>
+
+Some analysers are only run on the provided content packages. These can be changed with setting the user tasks:
+
+    <analyserUserTasks>
+        <analyserUserTask>bundle-content</analyserUserTask>
+    </analyserUserTasks>
 
 Please note that if you remove tasks which are run by default, the plugin might not report any errors in your project, while the analysers that run as part of the Cloud Manager pipeline might report errors.
 
 ### Configuring Analyser Tasks
 
 Some analyser tasks require configuration. Default configuration is used by the plugin for the default set of analysers. Additional or different configuration can be provided like this:
-
-    <analyserTasks>
-        <analyserTask>bundle-packages</analyserTask>
-        <analyserTask>requirements-capabilities</analyserTask>
-        <analyserTask>bundle-resources</analyserTask>
-        <analyserTask>api-regions-check-order</analyserTask>
-    </analyserTasks>
 
     <analyserTaskConfigurations>
         <api-regions-check-order>

--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -107,7 +107,7 @@ governing permissions and limitations under the License.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>aemanalyser-core</artifactId>
-      <version>1.0.8</version>
+      <version>1.0.9-SNAPSHOT</version>
     </dependency>
 
     <!-- Feature Model -->

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
@@ -89,11 +89,18 @@ public class AemAnalyseMojo extends AbstractMojo {
     List<Addon> addons;
     
     /**
-     * The analyser tasks run be the analyser
+     * The analyser tasks run be the analyser on the final aggregates
      */
     @Parameter(defaultValue = AemAnalyser.DEFAULT_TASKS,
         property = "analyserTasks")
     List<String> analyserTasks;
+
+    /**
+     * The analyser tasks run be the analyser on the user aggregates
+     */
+    @Parameter(defaultValue = AemAnalyser.DEFAULT_USER_TASKS,
+        property = "analyserUserTasks")
+    List<String> analyserUserTasks;
 
     /**
      * Optional configurations for the analyser tasks
@@ -338,6 +345,7 @@ public class AemAnalyseMojo extends AbstractMojo {
             final AemAnalyser analyser = new AemAnalyser();
             analyser.setArtifactProvider(artifactProvider);
             analyser.setIncludedTasks(this.getAnalyserTasks());
+            analyser.setIncludedUserTasks(this.getAnalyserUserTasks());
             analyser.setTaskConfigurations(this.getAnalyserTaskConfigurations());
 
             final AemAnalyserResult result = analyser.analyse(features);
@@ -427,6 +435,14 @@ public class AemAnalyseMojo extends AbstractMojo {
      */
     Set<String> getAnalyserTasks() {
         return new LinkedHashSet<>(this.analyserTasks);
+    }
+
+    /**
+     * Get the analyser user task
+     * @return The tasks
+     */
+    Set<String> getAnalyserUserTasks() {
+        return new LinkedHashSet<>(this.analyserUserTasks);
     }
 
     /**


### PR DESCRIPTION
This closes #111

## Description

A new analyser is added which executes the additional checks. In addition the analyser are now split up between "user" and "final" analyser. User analysers only run on the content package features, while the final analysers run on the final aggregates.


- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
