### PR TITLE
Get rid of deprecated maven-compat dependency

### DIFF
--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -118,11 +118,6 @@ governing permissions and limitations under the License.
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
-      <artifactId>maven-compat</artifactId>
-      <version>${maven.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
       <version>${maven.version}</version>
     </dependency>

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
@@ -185,12 +185,6 @@ public class AemAnalyseMojo extends AbstractMojo {
     @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
     private RepositorySystemSession repoSession;
 
-    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true, required = true)
-    private List<RemoteRepository> remoteProjectRepositories;
-
-    @Parameter(defaultValue = "${project.remotePluginRepositories}", readonly = true, required = true)
-    private List<RemoteRepository> remotePluginRepositories;
-
     @Parameter( defaultValue = "${plugin}", readonly = true ) // Maven 3 only
     private PluginDescriptor plugin;
  
@@ -244,7 +238,6 @@ public class AemAnalyseMojo extends AbstractMojo {
 
         final VersionUtil versionUtil = new VersionUtil(this.getLog(), this.project, artifactHandlerManager,
                 this.repoSystem, this.repoSession,
-                this.remoteProjectRepositories, this.remotePluginRepositories,
                 this.mavenSession.isOffline());
 
         versionUtil.checkPluginVersion(this.plugin.getGroupId(), this.plugin.getArtifactId(), this.plugin.getVersion());
@@ -568,9 +561,9 @@ public class AemAnalyseMojo extends AbstractMojo {
         if ( result == null ) {
             result = findArtifact(id, project.getAttachedArtifacts());
             if ( result == null ) {
-                result = findArtifact(id, project.getArtifacts());
+                result = findArtifact(id, project.getDependencyArtifacts());
                 if ( result == null ) {
-                    ArtifactRequest req = new ArtifactRequest(new org.eclipse.aether.artifact.DefaultArtifact(id.toMvnId()), remoteProjectRepositories, null);
+                    ArtifactRequest req = new ArtifactRequest(new org.eclipse.aether.artifact.DefaultArtifact(id.toMvnId()), project.getRemoteProjectRepositories(), null);
                     try {
                         ArtifactResult resolutionResult = repoSystem.resolveArtifact(repoSession, req);
                         result = RepositoryUtils.toArtifact(resolutionResult.getArtifact());

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/VersionUtil.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/VersionUtil.java
@@ -26,7 +26,6 @@ import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.artifact.Artifact;
 import org.eclipse.aether.artifact.DefaultArtifact;
-import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.VersionRequest;
 import org.eclipse.aether.resolution.VersionResolutionException;
 import org.eclipse.aether.resolution.VersionResult;
@@ -48,10 +47,6 @@ public class VersionUtil {
 
     private final RepositorySystemSession repoSession;
 
-    private final List<RemoteRepository> remoteProjectRepositories;
-
-    private final List<RemoteRepository> remotePluginRepositories;
-
     private final List<String> versionWarnings = new ArrayList<>();
 
     private final boolean isOffline;
@@ -61,16 +56,12 @@ public class VersionUtil {
             final ArtifactHandlerManager artifactHandlerManager,
             final RepositorySystem repoSystem,
             final RepositorySystemSession repoSession,
-            final List<RemoteRepository> remoteProjectRepositories,
-            final List<RemoteRepository> remotePluginRepositories,
             final boolean isOffline) {
         this.project = project;
         this.log = log;
         this.artifactHandlerManager = artifactHandlerManager;
         this.repoSystem = repoSystem;
         this.repoSession = repoSession;
-        this.remoteProjectRepositories = remoteProjectRepositories;
-        this.remotePluginRepositories = remotePluginRepositories;
         this.isOffline = isOffline;
     }
 
@@ -236,7 +227,7 @@ public class VersionUtil {
                 artifactHandlerManager.getArtifactHandler(dependency.getType()).getExtension(),
                 "RELEASE"); // this refers to the latest release version
 
-        VersionRequest versionRequest = new VersionRequest(artifact, PLUGIN_TYPE.equals(dependency.getType()) ? remotePluginRepositories :  remoteProjectRepositories, null);
+        VersionRequest versionRequest = new VersionRequest(artifact, PLUGIN_TYPE.equals(dependency.getType()) ? project.getRemotePluginRepositories() :  project.getRemoteProjectRepositories(), null);
         try {
             VersionResult result = repoSystem.resolveVersion(repoSession, versionRequest);
             return result.getVersion();

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/VersionUtil.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/VersionUtil.java
@@ -14,21 +14,22 @@ package com.adobe.aem.analyser.mojos;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.maven.artifact.Artifact;
-import org.apache.maven.artifact.ArtifactUtils;
-import org.apache.maven.artifact.DefaultArtifact;
 import org.apache.maven.artifact.handler.manager.ArtifactHandlerManager;
-import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
-import org.apache.maven.artifact.versioning.VersionRange;
 import org.apache.maven.model.Dependency;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
-import org.apache.maven.repository.legacy.metadata.ArtifactMetadataRetrievalException;
-import org.apache.maven.repository.legacy.metadata.ArtifactMetadataSource;
 import org.apache.sling.feature.ArtifactId;
+import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.artifact.Artifact;
+import org.eclipse.aether.artifact.DefaultArtifact;
+import org.eclipse.aether.repository.RemoteRepository;
+import org.eclipse.aether.resolution.VersionRequest;
+import org.eclipse.aether.resolution.VersionResolutionException;
+import org.eclipse.aether.resolution.VersionResult;
 
 /**
  * Helper methods to manage dependencies, versions, ...
@@ -43,13 +44,13 @@ public class VersionUtil {
 
     private final ArtifactHandlerManager artifactHandlerManager;
 
-    private final ArtifactMetadataSource artifactMetadataSource;
+    private final RepositorySystem repoSystem;
 
-    private final List<ArtifactRepository> remoteArtifactRepositories;
+    private final RepositorySystemSession repoSession;
 
-    private final List<ArtifactRepository> remotePluginRepositories;
+    private final List<RemoteRepository> remoteProjectRepositories;
 
-    private final ArtifactRepository localRepository;
+    private final List<RemoteRepository> remotePluginRepositories;
 
     private final List<String> versionWarnings = new ArrayList<>();
 
@@ -58,18 +59,18 @@ public class VersionUtil {
     public VersionUtil(final Log log,
             final MavenProject project,
             final ArtifactHandlerManager artifactHandlerManager,
-            final ArtifactMetadataSource artifactMetadataSource,
-            final List<ArtifactRepository> remoteArtifactRepositories,
-            final List<ArtifactRepository> remotePluginRepositories,
-            final ArtifactRepository localRepository,
+            final RepositorySystem repoSystem,
+            final RepositorySystemSession repoSession,
+            final List<RemoteRepository> remoteProjectRepositories,
+            final List<RemoteRepository> remotePluginRepositories,
             final boolean isOffline) {
         this.project = project;
         this.log = log;
         this.artifactHandlerManager = artifactHandlerManager;
-        this.artifactMetadataSource = artifactMetadataSource;
-        this.remoteArtifactRepositories = remoteArtifactRepositories;
+        this.repoSystem = repoSystem;
+        this.repoSession = repoSession;
+        this.remoteProjectRepositories = remoteProjectRepositories;
         this.remotePluginRepositories = remotePluginRepositories;
-        this.localRepository = localRepository;
         this.isOffline = isOffline;
     }
 
@@ -229,36 +230,17 @@ public class VersionUtil {
             this.versionWarnings.add("Plugin is used in offline mode, checking for latest version for " + dependency + " is disabled.");
             return null;
         }
-        try {
-            final Artifact artifact = new DefaultArtifact(dependency.getGroupId(),
+        final Artifact artifact = new DefaultArtifact(dependency.getGroupId(),
                 dependency.getArtifactId(),
-                VersionRange.createFromVersion(dependency.getVersion()),
-                Artifact.SCOPE_PROVIDED,
-                dependency.getType(),
                 dependency.getClassifier(),
-                artifactHandlerManager.getArtifactHandler(dependency.getType()));
+                artifactHandlerManager.getArtifactHandler(dependency.getType()).getExtension(),
+                "RELEASE"); // this refers to the latest release version
 
-            final List<ArtifactVersion> versions =
-                artifactMetadataSource.retrieveAvailableVersions( artifact, localRepository, 
-                        PLUGIN_TYPE.equals(dependency.getType()) ? remotePluginRepositories :  remoteArtifactRepositories);
-
-            ArtifactVersion latest = null;
-            for ( final ArtifactVersion candidate : versions ) {
-                if ( ArtifactUtils.isSnapshot( candidate.toString() ) ) {
-                    continue;
-                }
-
-                if ( latest == null ) {
-                    latest = candidate;
-                } else {
-                    if ( candidate.compareTo(latest) > 0 ) {
-                        latest = candidate;
-                    }
-                }
-            }
-            return latest != null ? latest.toString() : null;
-
-        } catch ( final ArtifactMetadataRetrievalException e) {
+        VersionRequest versionRequest = new VersionRequest(artifact, PLUGIN_TYPE.equals(dependency.getType()) ? remotePluginRepositories :  remoteProjectRepositories, null);
+        try {
+            VersionResult result = repoSystem.resolveVersion(repoSession, versionRequest);
+            return result.getVersion();
+        } catch (VersionResolutionException e) {
             throw new MojoExecutionException(e.getMessage(), e);
         }
     }

--- a/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/VersionUtilTest.java
+++ b/aemanalyser-maven-plugin/src/test/java/com/adobe/aem/analyser/mojos/VersionUtilTest.java
@@ -92,7 +92,7 @@ public class VersionUtilTest {
 
     private static class TestVersionUtil extends VersionUtil {
         private TestVersionUtil(final MavenProject prj) {
-            super(Mockito.mock(Log.class), prj, null, null, null, null, null, false);
+            super(Mockito.mock(Log.class), prj, null, null, null, false);
         }
 
         String getLatestVersion(final Dependency dependencies) throws MojoExecutionException {


### PR DESCRIPTION
Use Aether/Resolver API directly
This closes #127

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
