### PR TITLE
Disable bundle-content analyser

### DIFF
--- a/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemAnalyser.java
+++ b/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemAnalyser.java
@@ -59,8 +59,8 @@ public class AemAnalyser {
     /**
      * These tasks are executed on the user aggregates (before the product is merged in)
      */
-    public static final String DEFAULT_USER_TASKS = "bundle-content"
-        + ",bundle-resources"
+    public static final String DEFAULT_USER_TASKS =
+          "bundle-resources"
         + ",bundle-nativecode"
         + ",bundle-unversioned-packages"
 	    + ",artifact-rules"


### PR DESCRIPTION
As the content package to feature model converter supports Apache Slings initial content, we should remove this analyser from the default set.

## Related Issue

See #69 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
