### PR TITLE
Update VersionUtil to skip the maven-default-http-blocker

### DIFF
--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/VersionUtil.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/VersionUtil.java
@@ -256,10 +256,16 @@ public class VersionUtil {
     private List<RemoteRepository> getRemoteRepositoriesWithUpdatePolicy(List<RemoteRepository> repositories, String updatePolicy) {
         List<RemoteRepository> newRepositories = new ArrayList<>();
         for (RemoteRepository repo : repositories) {
-            RemoteRepository.Builder builder = new RemoteRepository.Builder(repo);
-            RepositoryPolicy newPolicy = new RepositoryPolicy(repo.getPolicy(false).isEnabled(), updatePolicy, repo.getPolicy(false).getChecksumPolicy());
-            builder.setPolicy(newPolicy);
-            newRepositories.add(builder.build());
+            // TODO: replace with RemoteRepository#isBlocked once #183 is merged (Change Maven minimum version to 3.8.1)
+            // https://maven.apache.org/resolver/apidocs/org/eclipse/aether/repository/RemoteRepository.html#isBlocked()
+            if (!repo.getId().equals("maven-default-http-blocker")) {
+                RemoteRepository.Builder builder = new RemoteRepository.Builder(repo);
+                RepositoryPolicy newPolicy = new RepositoryPolicy(repo.getPolicy(false).isEnabled(), updatePolicy, repo.getPolicy(false).getChecksumPolicy());
+                builder.setPolicy(newPolicy);
+                newRepositories.add(builder.build());    
+            } else {
+                this.log.debug("Skipping blocked repo: " + repo.getId());
+            }
         }
         return newRepositories;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #182 

This will be replaced by a call to RemoteRepository.isBlocked() once #183 is merged. This change sets the minumum Maven version to 3.8.1 which will allow us to use verison 1.9 of the Maven Artifact Resolver API which has this method.

See: https://maven.apache.org/resolver/apidocs/org/eclipse/aether/repository/RemoteRepository.html#isBlocked()

<!--- Describe your changes in detail -->

## Related Issue

#182 

## Motivation and Context

Discussion in #182 has a good summary of this motivation.

## How Has This Been Tested?

- Ran integration test suites
- Ran against a project I am working on that originally had the defect raised in #182. This update resolves that defect.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
