### PR TITLE
fix: Check global and deprecated region for usage of deprecated api

### DIFF
--- a/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemAnalyser.java
+++ b/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemAnalyser.java
@@ -151,6 +151,7 @@ public class AemAnalyser {
         config.computeIfAbsent("api-regions-crossfeature-dups", (key) -> apiRegionsCrossfeatureDupsDefaults());
         config.computeIfAbsent("content-packages-validation", (key) -> contentPackagesValidationDefaults());
         config.computeIfAbsent("api-regions-check-order", (key) -> apiRegionsCheckOrderDefaults());
+        config.computeIfAbsent("region-deprecated-api", (key) -> apiRegionsDeprecationDefaults());
     }
 
     private Map<String, String> apiRegionsCrossfeatureDupsDefaults() {
@@ -169,6 +170,9 @@ public class AemAnalyser {
         return singletonMap("order", "global,com.adobe.aem.deprecated,com.adobe.aem.internal");
     }
 
+    private Map<String, String> apiRegionsDeprecationDefaults() {
+        return singletonMap("regions", "global,com.adobe.aem.deprecated");
+    }
     /**
      * @return the artifactProvider
      */

--- a/aemanalyser-core/src/test/java/com/adobe/aem/analyser/AemAnalyserTest.java
+++ b/aemanalyser-core/src/test/java/com/adobe/aem/analyser/AemAnalyserTest.java
@@ -45,8 +45,8 @@ public class AemAnalyserTest {
         final AemAnalyser analyser = new AemAnalyser();
         assertNotNull(analyser.getTaskConfigurations());
 
-        // 3 configs by default
-        assertEquals(3, analyser.getTaskConfigurations().size());
+        // 4 configs by default
+        assertEquals(4, analyser.getTaskConfigurations().size());
        
         // check first config
         Map<String, String> config = analyser.getTaskConfigurations().get("api-regions-crossfeature-dups");
@@ -66,6 +66,11 @@ public class AemAnalyserTest {
         config = analyser.getTaskConfigurations().get("content-packages-validation");
         assertNotNull(config);
         assertEquals(1, config.size());
+
+        // check deprecation api config
+        config = analyser.getTaskConfigurations().get("region-deprecated-api");
+        assertNotNull(config);
+        assertEquals(1, config.size());
     }
 
     @Test public void testSetTaskConfigurations() throws Exception {
@@ -81,8 +86,8 @@ public class AemAnalyserTest {
         final AemAnalyser analyser = new AemAnalyser();
         analyser.setTaskConfigurations(taskConfigurations);
 
-        // 4 configurations (3 default + 1 custom)
-        assertEquals(4, analyser.getTaskConfigurations().size());
+        // 5 configurations (4 default + 1 custom)
+        assertEquals(5, analyser.getTaskConfigurations().size());
 
         // check overridden default config
         Map<String, String> config = analyser.getTaskConfigurations().get("api-regions-crossfeature-dups");
@@ -101,6 +106,12 @@ public class AemAnalyserTest {
         assertNotNull(config);
         assertEquals(1, config.size());
         assertEquals("global,com.adobe.aem.deprecated,com.adobe.aem.internal", config.get("order"));
+
+        // check deprecation api config - unchanged
+        config = analyser.getTaskConfigurations().get("region-deprecated-api");
+        assertNotNull(config);
+        assertEquals(1, config.size());
+        assertEquals("global,com.adobe.aem.deprecated", config.get("regions"));
     }
 
     @Test public void testSetIncludedTasks() throws Exception {


### PR DESCRIPTION
Include the deprecated region (which is used by default for the feature) in the check