### PR TITLE
In case of duplicate bundles, re-version the product bundle

### DIFF
--- a/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemAggregator.java
+++ b/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemAggregator.java
@@ -88,6 +88,24 @@ public class AemAggregator {
 
     private EnumSet<ServiceType> serviceTypes = EnumSet.allOf(ServiceType.class);
 
+    private boolean enableDuplicateBundleHandling = false;
+
+    /**
+     * Is the special handling for duplicate bundles enabled?
+     * @return {@code true} if enabled
+     */
+    public boolean isEnableDuplicateBundleHandling() {
+        return enableDuplicateBundleHandling;
+    }
+
+    /**
+     * Enable or disable the special handling for duplicate bundles
+     * @param enableDuplicateBundleHandling {@code true} to enable
+     */
+    public void setEnableDuplicateBundleHandling(boolean enableDuplicateBundleHandling) {
+        this.enableDuplicateBundleHandling = enableDuplicateBundleHandling;
+    }
+
     /**
      * @return the artifactProvider
      */
@@ -456,7 +474,7 @@ public class AemAggregator {
                   aggregate.getValue().toArray(new Feature[aggregate.getValue().size()]));
 
             // special handling for exactly same mvn coordinates in user and product feature
-            if ( mode == Mode.FINAL ) {
+            if ( mode == Mode.FINAL && this.isEnableDuplicateBundleHandling()) {
                 handleDuplicateBundles(aggregate, feature);
             }
 
@@ -498,10 +516,10 @@ public class AemAggregator {
         // check if a bundle from the user feature is in the product feature
         for(final Artifact userBundle : userFeature.getBundles()) {
             if ( productFeature.getBundles().contains(userBundle)) {
-                final Artifact mergedBundle = feature.getBundles().getExact(userBundle.getId());
                 logger.debug("Found duplicate bundle {} in user and product feature.", userBundle.getId().toMvnId());
 
                 // use bundle metadata from user provided bundle (e.g. origin)
+                final Artifact mergedBundle = feature.getBundles().getExact(userBundle.getId());
                 mergedBundle.getMetadata().clear();
                 mergedBundle.getMetadata().putAll(userBundle.getMetadata());
 

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
@@ -266,7 +266,8 @@ public class AemAnalyseMojo extends AbstractAnalyseMojo {
             a.setProjectId(new ArtifactId(project.getGroupId(), project.getArtifactId(), project.getVersion(), null, null));
             a.setSdkId(sdkId);
             a.setAddOnIds(addons);
-            
+            a.setEnableDuplicateBundleHandling(true);
+
             return a.aggregate();
         
         } catch (final IOException e) {


### PR DESCRIPTION
When two features are merged and both contain the exact same artifact (exact same mvn coordinates), then the resulting feature has that artifact only once - as it is the same.
With this patch, if the user feature and the product feature both contain the exact same bundle, this is checked after the features are merged and then the metadata is massaged:

For the bundle in the feature model, the artifact metadata from the user feature is used, basically changing the origin of that bundle to be from the user. In addition, the cached analyser metadata is removed as that one contains the "reporting" section which ignores all warnings/errors for this bundle. Removal of that metadata is not critical as this bundle is available to the build/run from the user feature anyway.

While this works for the pure analysing use cases, I am not 100% sure if the resulting feature can later on be used to actually start the instance as well as the origin of the bundle has changed and it is not in the internal region anymore.

This replaces #232 
This fixes #231 