### PR TITLE
Add analyser to check for implementating or extending ProviderType interfaces from AEM

### DIFF
--- a/aemanalyser-core/pom.xml
+++ b/aemanalyser-core/pom.xml
@@ -81,6 +81,13 @@ governing permissions and limitations under the License.
         <version>1.2.8</version>
     </dependency>
 
+    <!-- Class Scanning Analysers -->
+    <dependency>
+        <groupId>org.javassist</groupId>
+        <artifactId>javassist</artifactId>
+        <version>3.30.2-GA</version>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>junit</groupId>

--- a/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemAnalyser.java
+++ b/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemAnalyser.java
@@ -74,7 +74,8 @@ public class AemAnalyser {
 	    + ",artifact-rules"
         + ",aem-env-var"
         + ",repoinit"
-        + ",content-packages-validation";
+        + ",content-packages-validation"
+        + ",aem-provider-type";
 
     private static final String CONTENT_PACKAGE_ORIGINS = "content-package-origins";
     private static final String CONFIGURATION_ORIGINS = Configuration.CONFIGURATOR_PREFIX.concat(CONTENT_PACKAGE_ORIGINS);

--- a/aemanalyser-core/src/main/java/com/adobe/aem/analyser/impl/ProviderTypeAnalyserTask.java
+++ b/aemanalyser-core/src/main/java/com/adobe/aem/analyser/impl/ProviderTypeAnalyserTask.java
@@ -1,0 +1,177 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.jar.JarInputStream;
+
+import org.apache.felix.cm.json.io.Configurations;
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.analyser.task.AnalyserTask;
+import org.apache.sling.feature.analyser.task.AnalyserTaskContext;
+import org.apache.sling.feature.scanner.BundleDescriptor;
+import org.osgi.framework.Constants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonValue;
+import javassist.ClassPool;
+import javassist.CtClass;
+import javassist.bytecode.ClassFile;
+
+/**
+ * Feature model analyser task that checks if a class extends or implements a provider type.
+ */
+public class ProviderTypeAnalyserTask implements AnalyserTask {
+
+    /** Configuration property to enable strict checking */
+    private static final String CFG_STRICT = "strict";
+
+    private static final String PROVIDER_TYPES_FILE = "META-INF/api-info.json";
+    private static final String PROVIDER_TYPES_KEY = "providerTypes";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProviderTypeAnalyserTask.class);
+
+    private static final List<String> PROVIDER_TYPES = new ArrayList<>();
+
+    public static boolean initializeProviderTypeInfo(final ArtifactId sdkId, final File apiFile) {
+        try (final JarFile jarFile = new JarFile(apiFile)) {
+            final JarEntry entry = jarFile.getJarEntry(PROVIDER_TYPES_FILE);
+            if (entry != null) {
+                try (final InputStream is = jarFile.getInputStream(entry)) {
+                    final JsonObject providerTypeInfo = Json.createReader(is).readObject();
+                    if (providerTypeInfo.containsKey(PROVIDER_TYPES_KEY)) {
+                        for(final JsonValue v : providerTypeInfo.getJsonArray(PROVIDER_TYPES_KEY)) {
+                            PROVIDER_TYPES.add(Configurations.convertToObject(v).toString());
+                        }
+                        LOGGER.debug("Found {} provider types in {}", PROVIDER_TYPES.size(), sdkId.toMvnId());
+                        return true;
+                    }
+                }
+            } else {
+                LOGGER.error("API info not found in {}. Please update to a more recent version of the API. ", sdkId.toMvnId());
+            }
+        } catch ( final IOException ioe) {
+            LOGGER.error("Error while reading API info from {}", sdkId.toMvnId());
+        }
+        return false;
+    }
+
+    /** We cache the result to avoid rescanning classes files for bundles used in more than one feature. */
+    private static final Map<String, String> CHECKED_CLASSES = new HashMap<>();
+
+    @Override
+    public String getId() {
+        return "aem-provider-type";
+    }
+
+    @Override
+    public String getName() {
+        return "AEM Provider Type Analyser";
+    }
+
+    @Override
+    public void execute(final AnalyserTaskContext context) throws Exception {
+        if ( PROVIDER_TYPES.isEmpty() ) {
+            context.reportError("No provider types found.");
+            return;
+        }
+        final boolean strict = Boolean.parseBoolean(context.getConfiguration().get(CFG_STRICT));
+        for(final BundleDescriptor bundle : context.getFeatureDescriptor().getBundleDescriptors()) {
+            analyse(context, bundle, strict);
+        }
+    }
+
+    private void analyse(final AnalyserTaskContext context, final BundleDescriptor bundle, final boolean strict) {
+        try ( final JarInputStream jis = new JarInputStream(bundle.getArtifactFile().openStream())) {
+            JarEntry entry = null;
+            while ( (entry = jis.getNextJarEntry()) != null ) {
+                if (entry.getName().endsWith(".class") && !entry.getName().startsWith("META-INF/")) {
+                    final String className = entry.getName().substring(0, entry.getName().length() - 6).replace('/', '.');
+                    this.checkClass(context, bundle, className, jis, strict);
+                } else if (entry.getName().endsWith(".jar")) {
+                    // embedded jar?
+                    final String cp = bundle.getManifest().getMainAttributes().getValue(Constants.BUNDLE_CLASSPATH);
+                    if (cp != null) {
+                        for(final String path : cp.split(",")) {
+                            if (path.trim().equals(entry.getName())) {
+                                try (final JarInputStream ejis = new JarInputStream(jis)) {
+                                    JarEntry inner = null;
+                                    while ( (inner = ejis.getNextJarEntry()) != null ) {
+                                        if (inner.getName().endsWith(".class") && !inner.getName().startsWith("META-INF/")) {
+                                            final String className = inner.getName().substring(0, inner.getName().length() - 6).replace('/', '.');
+                                            this.checkClass(context, bundle, className, ejis, strict);
+                                        }
+                                    }
+                                }
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (final IOException e) {
+            context.reportError("Error while analysing bundle ".concat(bundle.getArtifact().getId().toMvnId()).concat(" : ").concat(e.getMessage()));
+        }
+    }
+
+    private void checkClass(final AnalyserTaskContext context, final BundleDescriptor bundle, final String className, final InputStream clazzStream, final boolean strict) throws IOException, RuntimeException {
+        final String key = bundle.getArtifact().getId().toMvnId().concat(":").concat(className);
+        String known = CHECKED_CLASSES.get(key);
+        if (known != null) {
+            this.reportProviderTypeUsage(context, bundle, className, known, strict);
+            return;
+        }
+        final CtClass cc = ClassPool.getDefault().makeClass(clazzStream);
+        cc.setName(className);
+
+        final ClassFile cfile = cc.getClassFile();
+        String result = "";
+        for(final String name : cfile.getInterfaces()) {
+            result = this.checkClassForProviderType(result, name);
+        }
+        result = this.checkClassForProviderType(result, cfile.getSuperclass());
+        this.reportProviderTypeUsage(context, bundle, className, result, strict);
+        CHECKED_CLASSES.put(key, result);
+    }
+
+    private void reportProviderTypeUsage(final AnalyserTaskContext context, final BundleDescriptor bundle, final String className, final String providerType, final boolean strict) {
+        if (!providerType.isEmpty()) {
+            final String msg = "Class ".concat(className).concat(" implements or extends an AEM provider type : ").concat(providerType);
+            if (strict) {
+                context.reportArtifactError(bundle.getArtifact().getId(), msg);
+            } else {
+                context.reportArtifactWarning(bundle.getArtifact().getId(), msg);
+            }
+        }
+    }
+
+    private String checkClassForProviderType(final String result, final String name) {
+        if (PROVIDER_TYPES.contains(name)) {
+            if (!result.isEmpty()) {
+                return result.concat(", ");
+            }
+            return result.concat(name);
+        }
+        return result;
+    }
+}

--- a/aemanalyser-core/src/main/resources/META-INF/services/org.apache.sling.feature.analyser.task.AnalyserTask
+++ b/aemanalyser-core/src/main/resources/META-INF/services/org.apache.sling.feature.analyser.task.AnalyserTask
@@ -1,1 +1,2 @@
 com.adobe.aem.analyser.impl.EnvVarAnalyserTask
+com.adobe.aem.analyser.impl.ProviderTypeAnalyserTask

--- a/aemanalyser-maven-plugin/README.md
+++ b/aemanalyser-maven-plugin/README.md
@@ -221,9 +221,9 @@ Please note that if you remove tasks which are run by default, the plugin might 
 Some analyser tasks require configuration. Default configuration is used by the plugin for the default set of analysers. Additional or different configuration can be provided like this:
 
     <analyserTaskConfigurations>
-        <api-regions-check-order>
-            <order>global,myregion</order>
-        </api-regions-check-order>
+        <aem-provider-type>
+            <strict>true</strict>
+        </aem-provider-type>
     </analyserTaskConfigurations>
 
 Please note, that overriding the default configuration for the analysers might hide errors locally that will be catched in the Cloud Manager pipeline.

--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -293,6 +293,13 @@ governing permissions and limitations under the License.
       <artifactId>plexus-archiver</artifactId>
       <version>4.8.0</version>
     </dependency>
+    <!-- Provider Type analyser-->
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.30.2-GA</version>
+    </dependency>
+
     <!-- Test -->
     <dependency>
       <groupId>junit</groupId>

--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AbstractAnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AbstractAnalyseMojo.java
@@ -21,6 +21,7 @@ import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.sling.feature.ArtifactId;
 
+import com.adobe.aem.analyser.impl.ProviderTypeAnalyserTask;
 import com.adobe.aem.analyser.result.AemAnalyserAnnotation;
 import com.adobe.aem.analyser.result.AemAnalyserResult;
 
@@ -118,6 +119,11 @@ public abstract class AbstractAnalyseMojo extends AbstractAemMojo {
 
         final ArtifactId sdkId = versionUtil.getSDKArtifactId(this.sdkArtifactId, this.sdkVersion, this.useDependencyVersions);
         final List<ArtifactId> addons = versionUtil.discoverAddons(this.addons, this.useDependencyVersions);
+
+        // initialize the provider types analyser
+        if ( !ProviderTypeAnalyserTask.initializeProviderTypeInfo(sdkId, this.getOrResolveArtifact(sdkId).getFile()) ) {
+            throw new MojoFailureException("Provider types not found in " + sdkId.toMvnId() + ". Please update to a more recent version of the API.");
+        }
 
         final AemAnalyserResult result = this.doExecute(sdkId, addons);
 


### PR DESCRIPTION
This closes #264

Add a new feature model analyser which scans the user class files if any of them implements an AEM provided ProviderType. The list of ProviderType is part of the AEM SDK API.

## Motivation and Context

This allows to get a warning already in the local build, avoiding the need to run a quality pipeline. In addition, all code is checked by this.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
