### PR TITLE
Don't close the input stream for embedded bundles

### DIFF
--- a/aem-project-tool/pom.xml
+++ b/aem-project-tool/pom.xml
@@ -16,7 +16,7 @@ governing permissions and limitations under the License.
   <parent>
     <groupId>com.adobe.aem</groupId>
     <artifactId>parent-oss</artifactId>
-    <version>5-SNAPSHOT</version>
+    <version>6</version>
     <relativePath>../parent-oss/pom.xml</relativePath>
   </parent>
 

--- a/aemanalyser-core/src/main/java/com/adobe/aem/analyser/impl/ProviderTypeAnalyserTask.java
+++ b/aemanalyser-core/src/main/java/com/adobe/aem/analyser/impl/ProviderTypeAnalyserTask.java
@@ -114,13 +114,12 @@ public class ProviderTypeAnalyserTask implements AnalyserTask {
                     if (cp != null) {
                         for(final String path : cp.split(",")) {
                             if (path.trim().equals(entry.getName())) {
-                                try (final JarInputStream ejis = new JarInputStream(jis)) {
-                                    JarEntry inner = null;
-                                    while ( (inner = ejis.getNextJarEntry()) != null ) {
-                                        if (inner.getName().endsWith(".class") && !inner.getName().startsWith("META-INF/")) {
-                                            final String className = inner.getName().substring(0, inner.getName().length() - 6).replace('/', '.');
-                                            this.checkClass(context, bundle, className, ejis, strict);
-                                        }
+                                final JarInputStream ejis = new JarInputStream(jis); // don't close this stream
+                                JarEntry inner = null;
+                                while ( (inner = ejis.getNextJarEntry()) != null ) {
+                                    if (inner.getName().endsWith(".class") && !inner.getName().startsWith("META-INF/")) {
+                                        final String className = inner.getName().substring(0, inner.getName().length() - 6).replace('/', '.');
+                                        this.checkClass(context, bundle, className, ejis, strict);
                                     }
                                 }
                                 break;
@@ -141,7 +140,7 @@ public class ProviderTypeAnalyserTask implements AnalyserTask {
             this.reportProviderTypeUsage(context, bundle, className, known, strict);
             return;
         }
-        final CtClass cc = ClassPool.getDefault().makeClass(clazzStream);
+        final CtClass cc = ClassPool.getDefault().makeClass(clazzStream); // don't close this stream
         cc.setName(className);
 
         final ClassFile cfile = cc.getClassFile();

--- a/aemanalyser-maven-plugin/pom.xml
+++ b/aemanalyser-maven-plugin/pom.xml
@@ -141,7 +141,7 @@ governing permissions and limitations under the License.
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>aemanalyser-core</artifactId>
-      <version>1.5.0</version>
+      <version>1.5.1-SNAPSHOT</version>
     </dependency>
 
     <!-- Feature Model -->


### PR DESCRIPTION
The outer jar input stream must not be closed when reading the embedded bundles

This fixes #279 


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
