### PR TITLE
SITES-23772 AEM Analyzer Plugin: CORS Configuration

### DIFF
--- a/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemAnalyser.java
+++ b/aemanalyser-core/src/main/java/com/adobe/aem/analyser/AemAnalyser.java
@@ -76,7 +76,8 @@ public class AemAnalyser {
         + ",repoinit"
         + ",content-packages-validation"
         + ",configurations-basic"
-        + ",aem-provider-type";
+        + ",aem-provider-type"
+        + ",cors-configuration-validator";
 
     private static final String CONTENT_PACKAGE_ORIGINS = "content-package-origins";
     private static final String CONFIGURATION_ORIGINS = Configuration.CONFIGURATOR_PREFIX.concat(CONTENT_PACKAGE_ORIGINS);

--- a/aemanalyser-core/src/main/java/com/adobe/aem/analyser/impl/CorsConfigurationValidator.java
+++ b/aemanalyser-core/src/main/java/com/adobe/aem/analyser/impl/CorsConfigurationValidator.java
@@ -1,0 +1,91 @@
+/*
+  Copyright 2025 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser.impl;
+
+import org.apache.sling.feature.Configuration;
+import org.apache.sling.feature.analyser.task.AnalyserTask;
+import org.apache.sling.feature.analyser.task.AnalyserTaskContext;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * Warn user about CORS settings blocking build in features
+ */
+public class CorsConfigurationValidator implements AnalyserTask {
+
+    static String ALLOW_ORIGIN = "alloworigin";
+    static String ALLOW_ORIGIN_REGEXP = "alloworiginregexp";
+    static Pattern COM_URL_PATTERN = Pattern.compile("https://.*\\.adobe\\.com");
+    static Pattern NET_URL_PATTERN = Pattern.compile("https://.*\\.adobe\\.net");
+    static String SAMPLE_COM_URL = "https://experience.adobe.com";
+    static String SAMPLE_NET_URL = "https://static.adobe.net";
+
+    @Override
+    public String getName() {
+        return "CORS Configuration Validator";
+    }
+
+    @Override
+    public String getId() {
+        return "cors-configuration-validator";
+    }
+    @Override
+    public void execute(final AnalyserTaskContext ctx) throws IOException {
+
+        List<Configuration> projectCorsConfigurations = ctx.getFeature().getConfigurations().stream()
+                .filter(c -> isCorsPolicyConfiguration(c, ctx))
+                .filter(c -> hasInvalidAllowOrigin(c, ctx) || hasInvalidAllowOriginRegex(c, ctx))
+                .collect(Collectors.toList());
+
+        for (final Configuration cfg : projectCorsConfigurations) {
+            ctx.reportConfigurationWarning(cfg,
+                     " overrides the default CORS Configuration for adobe.com/adobe.net and will block Headless UIs." +
+                             " Please reconfigure your project to avoid blocking these features."
+            );
+        }
+    }
+
+    private static boolean isCorsPolicyConfiguration(Configuration configuration, AnalyserTaskContext ctx) {
+        return "com.adobe.granite.cors.impl.CORSPolicyImpl".equals(configuration.getFactoryPid());
+    }
+
+    private static boolean hasInvalidAllowOrigin(Configuration configuration, AnalyserTaskContext ctx) {
+        String[] property = getConfigurationProperty(configuration, ALLOW_ORIGIN);
+
+        return property != null
+                && Arrays.stream(property).anyMatch(regex -> COM_URL_PATTERN.matcher(regex).matches()
+                || NET_URL_PATTERN.matcher(regex).matches());
+    }
+    private static boolean hasInvalidAllowOriginRegex(Configuration configuration, AnalyserTaskContext ctx) {
+        String[] property = getConfigurationProperty(configuration, ALLOW_ORIGIN_REGEXP);
+
+        return property != null && Arrays.stream(property).anyMatch(regex -> Pattern.compile(regex).matcher(SAMPLE_COM_URL).matches()
+                || Pattern.compile(regex).matcher(SAMPLE_NET_URL).matches());
+
+    }
+
+    private static String[] getConfigurationProperty(Configuration configuration, String propertyName) {
+        Object property = configuration.getConfigurationProperties().get(propertyName);
+
+        if (property instanceof String) {
+            return new String[]{(String) property};
+        } else {
+            return (String[]) property;
+
+        }
+    }
+
+}

--- a/aemanalyser-core/src/main/resources/META-INF/services/org.apache.sling.feature.analyser.task.AnalyserTask
+++ b/aemanalyser-core/src/main/resources/META-INF/services/org.apache.sling.feature.analyser.task.AnalyserTask
@@ -1,3 +1,4 @@
 com.adobe.aem.analyser.impl.EnvVarAnalyserTask
 com.adobe.aem.analyser.impl.ProviderTypeAnalyserTask
 com.adobe.aem.analyser.impl.ProductPackageImportTask
+com.adobe.aem.analyser.impl.CorsConfigurationValidator

--- a/aemanalyser-core/src/test/java/com/adobe/aem/analyser/impl/CorsConfigurationValidatorTest.java
+++ b/aemanalyser-core/src/test/java/com/adobe/aem/analyser/impl/CorsConfigurationValidatorTest.java
@@ -1,0 +1,121 @@
+/*
+  Copyright 2025 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser.impl;
+
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Configuration;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.analyser.task.AnalyserTask;
+import org.apache.sling.feature.analyser.task.AnalyserTaskContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+public class CorsConfigurationValidatorTest {
+
+    @Mock
+    AnalyserTaskContext ctx;
+
+    private AutoCloseable closeable;
+
+    @Before
+    public void openMocks() {
+        closeable = MockitoAnnotations.openMocks(this);
+    }
+
+    @After
+    public void releaseMocks() throws Exception {
+        closeable.close();
+    }
+
+    @Test
+    public void testTaskIdentifiers() {
+        AnalyserTask task = new CorsConfigurationValidator();
+        assertEquals("cors-configuration-validator", task.getId());
+        assertEquals("CORS Configuration Validator", task.getName());
+    }
+
+    @Test
+    public void testValidCorsConfigurations() throws Exception {
+        List<Configuration> configurations = List.of(
+                createConfiguration("regexp-array", null, new String[]{"https://.*\\.something\\.com"}),
+                createConfiguration("regexp-string", null, "https://.*\\.something\\.com"),
+                createConfiguration("singleorigin-array", new String[]{"https://something.com"}, null),
+                createConfiguration("singleorigin-string", "https://something.com", null),
+                createConfiguration("no-config", null, null)
+        );
+        initializeFeatureWithConfigurations(configurations);
+
+        AnalyserTask task = new CorsConfigurationValidator();
+        task.execute(ctx);
+
+        verify(ctx).getFeature();
+        verify(ctx, times(0)).reportConfigurationWarning(any(), anyString());
+        verifyNoMoreInteractions(ctx);
+    }
+
+    @Test
+    public void testNonCorsConfigurations() throws Exception {
+        Configuration configuration = mock(Configuration.class);
+        when(configuration.getFactoryPid()).thenReturn("not.CORSPolicyImpl");
+        List<Configuration> configurations = List.of(configuration);
+        initializeFeatureWithConfigurations(configurations);
+
+        AnalyserTask task = new CorsConfigurationValidator();
+        task.execute(ctx);
+
+        verify(configuration, times(0)).getConfigurationProperties();
+    }
+
+    @Test
+    public void testInvalidCorsConfigurations() throws Exception {
+        List<Configuration> configurations = List.of(
+                createConfiguration("regexp-com", null, new String[]{"https://.*\\.adobe\\.com"}),
+                createConfiguration("regexp-net", null, new String[]{"https://.*\\.adobe\\.net"}),
+                createConfiguration("regexp-string", null, "https://.*\\.adobe\\.net"),
+                createConfiguration("singleorigin-com", new String[]{"https://any.adobe.com"}, null),
+                createConfiguration("singleorigin-net", new String[]{"https://any.adobe.net"}, null),
+                createConfiguration("singleorigin-string", "https://any.adobe.net", null)
+        );
+        initializeFeatureWithConfigurations(configurations);
+
+        AnalyserTask task = new CorsConfigurationValidator();
+        task.execute(ctx);
+
+        verify(ctx).getFeature();
+        for (Configuration c : configurations) {
+            verify(ctx, times(1)).reportConfigurationWarning(eq(c), anyString());
+        }
+        verifyNoMoreInteractions(ctx);
+    }
+
+    private void initializeFeatureWithConfigurations(List<Configuration> configurations) {
+        Feature feature = new Feature(ArtifactId.parse("g:a:1"));
+        when(ctx.getFeature()).thenReturn(feature);
+        feature.getConfigurations().addAll(configurations);
+    }
+
+    private Configuration createConfiguration(String name, Object alloworigin, Object alloworiginregexp) {
+        Configuration configuration = new Configuration("com.adobe.granite.cors.impl.CORSPolicyImpl~" + name);
+        if (alloworigin != null) configuration.getProperties().put("alloworigin", alloworigin);
+        if (alloworiginregexp != null) configuration.getProperties().put("alloworiginregexp", alloworiginregexp);
+        return configuration;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
New Task that checks if none of the Project Configurations overrides the build-in `com.adobe.granite.cors.impl.CORSPolicyImpl` settings.
<!--- Describe your changes in detail -->

## Related Issue
 SITES-23772 _AEM Analyzer Plugin: CORS Configuration_
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
We have multiple customers facing CORS issues which are widely back-traceable to a custom CORS configuration including the adobe.com domain.

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
I've run the plugin on a project created from the AEM Project Archetype + several correct & invalid configurations.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
n/a
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
