### PR TITLE
Update README.md for using addons locally

### DIFF
--- a/aemanalyser-maven-plugin/README.md
+++ b/aemanalyser-maven-plugin/README.md
@@ -281,9 +281,9 @@ The plugin provides a global configuration to enabled `strict` checking. With th
 
 When running the AEM Analyser Maven Plugin locally, it's important to note that the program add-ons are not included by default. This add-ons are automatically injected by Cloud Manager during pipeline execution, but when executing the analyser locally, you must manually include them to ensure the analysis runs successfully.
 
-If no <addons> are explicitly defined in your configuration, the following add-ons are included by default:
-    * com.adobe.aem:aem-forms-sdk-api
-    * com.adobe.cq:aem-cif-sdk-api
+If no add-ons are explicitly defined in your configuration, the following add-ons are included by default:
+* com.adobe.aem:aem-forms-sdk-api
+* com.adobe.cq:aem-cif-sdk-api
 
 To override the default behavior and include a custom set of add-ons in your local analyser configuration, you can explicitly define the desired add-ons like this:
 

--- a/aemanalyser-maven-plugin/README.md
+++ b/aemanalyser-maven-plugin/README.md
@@ -281,22 +281,25 @@ The plugin provides a global configuration to enabled `strict` checking. With th
 
 When running the AEM Analyser Maven Plugin locally, it's important to note that the program add-ons are not included by default. This add-ons are automatically injected by Cloud Manager during pipeline execution, but when executing the analyser locally, you must manually include them to ensure the analysis runs successfully.
 
-To include an add-on in your local analyser configuration, you con configure it like this:
+If no <addons> are explicitly defined in your configuration, the following add-ons are included by default:
+    * com.adobe.aem:aem-forms-sdk-api
+    * com.adobe.cq:aem-cif-sdk-api
 
-    <addons>
-        <addon>
-            <groupId></groupId>
-            <artifactId></artifactId>
-            <classifier></classifier>
-        </addon>
-    </addons>
+To override the default behavior and include a custom set of add-ons in your local analyser configuration, you can explicitly define the desired add-ons like this:
 
-This `addons` section is added under the `configuration` section like this:
+E.g Adding the AEM Guides Add-on 
 
     <configuration>
         <addons>
+            <addon>
+                <groupId>com.adobe.aem</groupId>
+                <artifactId>aem-dox-sdk-api</artifactId>
+                <classifier>aem-dox-sdk</classifier>
+            </addon>
         </addons>
     </configuration>
+
+This will ensure that the AEM Guides add-on is used during local analysis.
     
 ## Deprecated Maven Goals
 

--- a/aemanalyser-maven-plugin/README.md
+++ b/aemanalyser-maven-plugin/README.md
@@ -277,6 +277,27 @@ The plugin provides a global configuration to enabled `strict` checking. With th
         </aem-provider-type>
     </analyserTaskConfigurations>
 
+### Running AEM Analyser locally with additional Add-Ons
+
+When running the AEM Analyser Maven Plugin locally, it's important to note that the program add-ons are not included by default. This add-ons are automatically injected by Cloud Manager during pipeline execution, but when executing the analyser locally, you must manually include them to ensure the analysis runs successfully.
+
+To include an add-on in your local analyser configuration, you con configure it like this:
+
+    <addons>
+        <addon>
+            <groupId></groupId>
+            <artifactId></artifactId>
+            <classifier></classifier>
+        </addon>
+    </addons>
+
+This `addons` section is added under the `configuration` section like this:
+
+    <configuration>
+        <addons>
+        </addons>
+    </configuration>
+    
 ## Deprecated Maven Goals
 
 Both, the `aggregate` as well as the `convert` Maven mojo have been deprecated. It is recommended to remove them from your project. Their implementation has been changed to do no work. All work has been moved into the remaining `analyse` mojo.


### PR DESCRIPTION

## Description

Update in README.md. adding section for  running AEM Analyser Locally with Additional Add-Ons

## Related Issue

https://github.com/adobe/aemanalyser-maven-plugin/issues/319

## Motivation and Context

Adding documentation for how to use an addOn locally with Aem Analyser
## How Has This Been Tested?

The steps have been tested by creating maven project and adding a aem guides addon locally and running the aem analyser

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
