### PR TITLE
Only throw MojoExecutionException when classifier is not found

### DIFF
--- a/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
+++ b/aemanalyser-maven-plugin/src/main/java/com/adobe/aem/analyser/mojos/AemAnalyseMojo.java
@@ -202,7 +202,9 @@ public class AemAnalyseMojo extends AbstractAnalyseMojo {
                         result.add(artifact);
                     }
                 }
-                throw new MojoExecutionException("No attached artifact with classifier " + classifier + " found for project.");
+                if (result.isEmpty()) {
+                    throw new MojoExecutionException("No attached artifact with classifier " + classifier + " found for project.");
+                }
             } else {
                 // Use the current project artifact as the content package
                 getLog().info("Using current project as content package: " + project.getArtifact());


### PR DESCRIPTION
This fixes a regression introduced with
https://github.com/adobe/aemanalyser-maven-plugin/commit/84b60a7a54431096aa391143c6b0aa9ce466ab59 as that lead to the fact that
"org.apache.maven.plugin.MojoExecutionException: No attached artifact with classifier cloud found for project." was always emitted, even if the attached classifier was in fact found.

This closes #340

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
