### PR TITLE
Added merging prerelease sdk and addons with regular one

### DIFF
--- a/src/main/java/com/adobe/aem/analyser/AemAggregator.java
+++ b/src/main/java/com/adobe/aem/analyser/AemAggregator.java
@@ -84,7 +84,11 @@ public class AemAggregator {
 
     private ArtifactId sdkId;
 
+    private ArtifactId prereleaseSdkId;
+
     private List<ArtifactId> addOnIds;
+
+    private List<ArtifactId> prereleaseAddOnIds;
 
     private EnumSet<ServiceType> serviceTypes = EnumSet.allOf(ServiceType.class);
 
@@ -164,7 +168,12 @@ public class AemAggregator {
 
     public ProductFeatureGenerator getProductFeatureGenerator() {
         if ( productFeatureGenerator == null )
-            return new AemSdkProductFeatureGenerator(getFeatureProvider(), getSdkId(), getAddOnIds());
+            return new AemSdkProductFeatureGenerator(
+                    getFeatureProvider(),
+                    getSdkId(),
+                    getPrereleaseSdkId(),
+                    getAddOnIds(),
+                    getPrereleaseAddOnIds());
         return productFeatureGenerator;
     }
 
@@ -249,6 +258,20 @@ public class AemAggregator {
     }
 
     /**
+     * @return the prereleaseSdkId
+     */
+    public ArtifactId getPrereleaseSdkId() {
+        return prereleaseSdkId;
+    }
+
+    /**
+     * @param prereleaseSdkId the prereleaseSdkId to set
+     */
+    public void setPrereleaseSdkId(final ArtifactId prereleaseSdkId) {
+        this.prereleaseSdkId = prereleaseSdkId;
+    }
+
+    /**
      * @return the addOnIds
      */
     public List<ArtifactId> getAddOnIds() {
@@ -260,6 +283,20 @@ public class AemAggregator {
      */
     public void setAddOnIds(final List<ArtifactId> addOnIds) {
         this.addOnIds = addOnIds;
+    }
+
+    /**
+     * @return the prereleaseAddOnIds
+     */
+    public List<ArtifactId> getPrereleaseAddOnIds() {
+        return prereleaseAddOnIds;
+    }
+
+    /**
+     * @param prereleaseAddOnIds the prereleaseAddOnIds to set
+     */
+    public void setPrereleaseAddOnIds(final List<ArtifactId> prereleaseAddOnIds) {
+        this.prereleaseAddOnIds = prereleaseAddOnIds;
     }
 
     public enum Mode {

--- a/src/main/java/com/adobe/aem/analyser/AemSdkProductFeatureGenerator.java
+++ b/src/main/java/com/adobe/aem/analyser/AemSdkProductFeatureGenerator.java
@@ -16,13 +16,17 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.apache.sling.feature.ArtifactId;
 import org.apache.sling.feature.Feature;
 import org.apache.sling.feature.builder.FeatureProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.adobe.aem.project.ServiceType;
 
@@ -31,14 +35,37 @@ import com.adobe.aem.project.ServiceType;
  */
 public class AemSdkProductFeatureGenerator implements ProductFeatureGenerator {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AemSdkProductFeatureGenerator.class);
     private final FeatureProvider featureProvider;
     private final ArtifactId sdkId;
+    private final ArtifactId prereleaseSdkId;
     private final List<ArtifactId> addOnIds;
+    private final List<ArtifactId> prereleaseAddOnIds;
+    private final FeatureConflictResolver conflictResolver;
 
-    public AemSdkProductFeatureGenerator(FeatureProvider featureProvider, ArtifactId sdkId, List<ArtifactId> addOnIds) {
+    public AemSdkProductFeatureGenerator(
+            FeatureProvider featureProvider,
+            ArtifactId sdkId,
+            ArtifactId prereleaseSdkId,
+            List<ArtifactId> addOnIds,
+            List<ArtifactId> prereleaseAddOnIds) {
+        this(featureProvider, sdkId, prereleaseSdkId, addOnIds, prereleaseAddOnIds,
+                new AssemblyBasedFeatureConflictResolver());
+    }
+
+    public AemSdkProductFeatureGenerator(
+            FeatureProvider featureProvider,
+            ArtifactId sdkId,
+            ArtifactId prereleaseSdkId,
+            List<ArtifactId> addOnIds,
+            List<ArtifactId> prereleaseAddOnIds,
+            FeatureConflictResolver conflictResolver) {
         this.featureProvider = featureProvider;
         this.sdkId = sdkId;
+        this.prereleaseSdkId = prereleaseSdkId;
         this.addOnIds = addOnIds == null ? Collections.emptyList() : addOnIds;
+        this.prereleaseAddOnIds = prereleaseAddOnIds == null ? Collections.emptyList() : prereleaseAddOnIds;
+        this.conflictResolver = conflictResolver;
     }
 
     @Override
@@ -54,18 +81,12 @@ public class AemSdkProductFeatureGenerator implements ProductFeatureGenerator {
                 continue;
 
             final List<Feature> list = aggregates.computeIfAbsent(variation, n -> new ArrayList<>());
-            final Feature sdkFeature = featureProvider.provide(sdkId
-                    .changeClassifier(getProductClassifier(variation))
-                    .changeType(AemAggregator.FEATUREMODEL_TYPE));
-            if ( sdkFeature == null ) {
-                throw new IOException("Unable to find SDK feature for " + sdkId.toMvnId());
-            }
+            final Feature sdkFeature = getSdkFeature(variation);
             list.add(sdkFeature);
+            final Map<String, ArtifactId> prereleaseByKey = toPrereleaseAddOnMap(prereleaseAddOnIds);
             for(final ArtifactId id : addOnIds) {
-                final Feature feature = featureProvider.provide(id.changeType(AemAggregator.FEATUREMODEL_TYPE));
-                if ( feature == null ) {
-                    throw new IOException("Unable to find addon feature for " + id.toMvnId());
-                }
+                final ArtifactId prereleaseId = prereleaseByKey.get(addOnKey(id));
+                final Feature feature = getAddOnFeature(id, prereleaseId, variation);
                 list.add(feature);
             }
         }
@@ -73,8 +94,93 @@ public class AemSdkProductFeatureGenerator implements ProductFeatureGenerator {
         return aggregates;
     }
 
+    private Feature getSdkFeature(final SdkProductVariation variation) throws IOException {
+        final Feature stableFeature = resolveSdkFeature(sdkId, variation);
+        if (prereleaseSdkId == null) {
+            LOGGER.info("Using SDK feature {} for {} because prerelease SDK is not configured.",
+                    stableFeature.getId().toMvnId(), variation);
+            return stableFeature;
+        }
+
+        final Feature prereleaseFeature = resolveSdkFeature(prereleaseSdkId, variation);
+        return selectFeatureByVersion(stableFeature, prereleaseFeature, variation);
+    }
+
+    private Feature getAddOnFeature(final ArtifactId stableAddOnId,
+            final ArtifactId prereleaseAddOnId,
+            final SdkProductVariation variation) throws IOException {
+        final Feature stableFeature = resolveAddOnFeature(stableAddOnId);
+        if (prereleaseAddOnId == null) {
+            LOGGER.info("Using add-on feature {} for {} because prerelease add-on is not configured.",
+                    stableFeature.getId().toMvnId(), variation);
+            return stableFeature;
+        }
+
+        final Feature prereleaseFeature = resolveAddOnFeature(prereleaseAddOnId);
+        return selectFeatureByVersion(stableFeature, prereleaseFeature, variation);
+    }
+
+    private Feature resolveSdkFeature(final ArtifactId sourceSdkId, final SdkProductVariation variation) throws IOException {
+        final ArtifactId featureId = sourceSdkId
+                .changeClassifier(getProductClassifier(variation))
+                .changeType(AemAggregator.FEATUREMODEL_TYPE);
+        final Feature feature = featureProvider.provide(featureId);
+        if (feature == null) {
+            throw new IOException("Unable to find feature for " + sourceSdkId.toMvnId());
+        }
+        return feature;
+    }
+
+    private Feature resolveAddOnFeature(final ArtifactId sourceAddOnId) throws IOException {
+        final ArtifactId featureId = sourceAddOnId.changeType(AemAggregator.FEATUREMODEL_TYPE);
+        final Feature feature = featureProvider.provide(featureId);
+        if (feature == null) {
+            throw new IOException("Unable to find feature for " + sourceAddOnId.toMvnId());
+        }
+        return feature;
+    }
+
+    private int compareFeatureVersions(final ArtifactId stable, final ArtifactId prerelease) {
+        return stable.getVersion().compareTo(prerelease.getVersion());
+    }
+
+    private Feature selectFeatureByVersion(final Feature stableFeature,
+            final Feature prereleaseFeature,
+            final SdkProductVariation variation) {
+        final int comparison = compareFeatureVersions(stableFeature.getId(), prereleaseFeature.getId());
+        final String stableId = stableFeature.getId().toMvnId();
+        final String prereleaseId = prereleaseFeature.getId().toMvnId();
+
+        if (comparison > 0) {
+            LOGGER.info("Using stable feature {} for {} because it has newer version than {}.",
+                    stableId, variation, prereleaseId);
+            return stableFeature;
+        }
+        if (comparison < 0) {
+            LOGGER.info("Using prerelease feature {} for {} because it has newer version than {}.",
+                    prereleaseId, variation, stableId);
+            return prereleaseFeature;
+        }
+
+        LOGGER.info("Features {} and {} have the same version for {}. Using conflict resolver.",
+                stableId, prereleaseId, variation);
+        return conflictResolver.resolveVersionConflict(stableFeature, prereleaseFeature, variation);
+    }
+
     protected String getProductClassifier(SdkProductVariation variation) {
         return variation.getSdkClassifier();
+    }
+
+    private Map<String, ArtifactId> toPrereleaseAddOnMap(final List<ArtifactId> addOnIds) {
+        final Map<String, ArtifactId> byKey = new LinkedHashMap<>();
+        for (final ArtifactId id : addOnIds) {
+            byKey.put(addOnKey(id), id);
+        }
+        return byKey;
+    }
+
+    private String addOnKey(final ArtifactId id) {
+        return id.getGroupId() + ":" + Objects.toString(id.getClassifier(), "") + ":" + Objects.toString(id.getType(), "");
     }
 
     @Override

--- a/src/main/java/com/adobe/aem/analyser/AemSdkProductFeatureGenerator.java
+++ b/src/main/java/com/adobe/aem/analyser/AemSdkProductFeatureGenerator.java
@@ -97,8 +97,6 @@ public class AemSdkProductFeatureGenerator implements ProductFeatureGenerator {
     private Feature getSdkFeature(final SdkProductVariation variation) throws IOException {
         final Feature stableFeature = resolveSdkFeature(sdkId, variation);
         if (prereleaseSdkId == null) {
-            LOGGER.info("Using SDK feature {} for {} because prerelease SDK is not configured.",
-                    stableFeature.getId().toMvnId(), variation);
             return stableFeature;
         }
 
@@ -111,8 +109,6 @@ public class AemSdkProductFeatureGenerator implements ProductFeatureGenerator {
             final SdkProductVariation variation) throws IOException {
         final Feature stableFeature = resolveAddOnFeature(stableAddOnId);
         if (prereleaseAddOnId == null) {
-            LOGGER.info("Using add-on feature {} for {} because prerelease add-on is not configured.",
-                    stableFeature.getId().toMvnId(), variation);
             return stableFeature;
         }
 
@@ -152,8 +148,8 @@ public class AemSdkProductFeatureGenerator implements ProductFeatureGenerator {
         final String prereleaseId = prereleaseFeature.getId().toMvnId();
 
         if (comparison > 0) {
-            LOGGER.info("Using stable feature {} for {} because it has newer version than {}.",
-                    stableId, variation, prereleaseId);
+            LOGGER.info("Found prerelease feature {} for {} but not using because it is has a different version than release {}",
+                    prereleaseId, variation, stableId);
             return stableFeature;
         }
         if (comparison < 0) {
@@ -162,7 +158,7 @@ public class AemSdkProductFeatureGenerator implements ProductFeatureGenerator {
             return prereleaseFeature;
         }
 
-        LOGGER.info("Features {} and {} have the same version for {}. Using conflict resolver.",
+        LOGGER.info("Features {} and {} have the same version for {}. Using result of merging both",
                 stableId, prereleaseId, variation);
         return conflictResolver.resolveVersionConflict(stableFeature, prereleaseFeature, variation);
     }

--- a/src/main/java/com/adobe/aem/analyser/AemSdkProductFeatureGenerator.java
+++ b/src/main/java/com/adobe/aem/analyser/AemSdkProductFeatureGenerator.java
@@ -147,20 +147,16 @@ public class AemSdkProductFeatureGenerator implements ProductFeatureGenerator {
         final String stableId = stableFeature.getId().toMvnId();
         final String prereleaseId = prereleaseFeature.getId().toMvnId();
 
-        if (comparison > 0) {
-            LOGGER.info("Found prerelease feature {} for {} but not using because it is has a different version than release {}",
-                    prereleaseId, variation, stableId);
-            return stableFeature;
-        }
-        if (comparison < 0) {
-            LOGGER.info("Using prerelease feature {} for {} because it has newer version than {}.",
-                    prereleaseId, variation, stableId);
-            return prereleaseFeature;
+        if (comparison == 0) {
+            LOGGER.info("Features {} and {} have the same version for {}. Using result of merging both",
+                    stableId, prereleaseId, variation);
+
+            return conflictResolver.resolveVersionConflict(stableFeature, prereleaseFeature, variation);
         }
 
-        LOGGER.info("Features {} and {} have the same version for {}. Using result of merging both",
-                stableId, prereleaseId, variation);
-        return conflictResolver.resolveVersionConflict(stableFeature, prereleaseFeature, variation);
+        LOGGER.info("Found prerelease feature {} for {} but not using because it is has a different version than release {}",
+                prereleaseId, variation, stableId);
+        return stableFeature;
     }
 
     protected String getProductClassifier(SdkProductVariation variation) {

--- a/src/main/java/com/adobe/aem/analyser/ApiRegionsMergeHandler.java
+++ b/src/main/java/com/adobe/aem/analyser/ApiRegionsMergeHandler.java
@@ -1,0 +1,108 @@
+package com.adobe.aem.analyser;
+
+import jakarta.json.*;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Utility responsible for merging the {@code api-regions} JSON extension content.
+ *
+ * <p>The merge iterates over prerelease regions and keeps prerelease data by default.
+ * For matching regions, stable {@code exports} are reused only when prerelease does not
+ * provide exports (missing or empty array).</p>
+ */
+class ApiRegionsMergeHandler {
+
+    private ApiRegionsMergeHandler() {
+    }
+
+    /**
+     * Merges two {@code api-regions} JSON arrays and returns the resulting JSON text.
+     *
+     * <p>Prerelease content is the baseline. Stable {@code exports} are copied only for
+     * matching regions where prerelease exports are missing or empty. If either JSON input
+     * is blank, null, or cannot be parsed as an array, the method falls back to
+     * {@code prereleaseJson} unchanged.</p>
+     *
+     * @param stableJson stable {@code api-regions} JSON array text
+     * @param prereleaseJson prerelease {@code api-regions} JSON array text
+     * @return merged {@code api-regions} JSON array text, or {@code prereleaseJson} on fallback
+     */
+    static String merge(final String stableJson, final String prereleaseJson) {
+        final JsonArray stableRegions = parseJsonArray(stableJson);
+        final JsonArray prereleaseRegions = parseJsonArray(prereleaseJson);
+        if (stableRegions == null || prereleaseRegions == null) {
+            return prereleaseJson;
+        }
+
+        final Map<String, JsonObject> stableRegionsByName = new LinkedHashMap<>();
+        for (final JsonValue regionVal : stableRegions) {
+            if (regionVal.getValueType() == JsonValue.ValueType.OBJECT) {
+                final JsonObject region = regionVal.asJsonObject();
+                final String regionName = region.getString("name", null);
+                if (regionName != null) {
+                    stableRegionsByName.put(regionName, region);
+                }
+            }
+        }
+
+        final JsonArrayBuilder mergedRegions = Json.createArrayBuilder();
+        for (final JsonValue regionVal : prereleaseRegions) {
+            if (regionVal.getValueType() != JsonValue.ValueType.OBJECT) {
+                mergedRegions.add(regionVal);
+                continue;
+            }
+
+            final JsonObject prereleaseRegion = regionVal.asJsonObject();
+            final String regionName = prereleaseRegion.getString("name", null);
+            final JsonObject stableRegion = stableRegionsByName.get(regionName);
+            if (regionName == null || stableRegion == null || !shouldUseStableExports(prereleaseRegion, stableRegion)) {
+                mergedRegions.add(prereleaseRegion);
+                continue;
+            }
+
+            final JsonObjectBuilder mergedRegion = Json.createObjectBuilder();
+            for (final Map.Entry<String, JsonValue> entry : prereleaseRegion.entrySet()) {
+                if (!"exports".equals(entry.getKey())) {
+                    mergedRegion.add(entry.getKey(), entry.getValue());
+                }
+            }
+            mergedRegion.add("exports", stableRegion.getJsonArray("exports"));
+            mergedRegions.add(mergedRegion);
+        }
+
+        final StringWriter writer = new StringWriter();
+        try (final JsonWriter jsonWriter = Json.createWriter(writer)) {
+            jsonWriter.writeArray(mergedRegions.build());
+        }
+        return writer.toString();
+    }
+
+    private static boolean shouldUseStableExports(final JsonObject prereleaseRegion, final JsonObject stableRegion) {
+        final JsonArray stableExports = stableRegion.getJsonArray("exports");
+        if (stableExports == null || stableExports.isEmpty()) {
+            return false;
+        }
+
+        if (!prereleaseRegion.containsKey("exports")) {
+            return true;
+        }
+        final JsonValue prereleaseExports = prereleaseRegion.get("exports");
+        return prereleaseExports.getValueType() == JsonValue.ValueType.ARRAY
+                && prereleaseExports.asJsonArray().isEmpty();
+    }
+
+    private static JsonArray parseJsonArray(final String json) {
+        if (json == null || json.isBlank()) {
+            return null;
+        }
+        try (final JsonReader jsonReader = Json.createReader(new StringReader(json))) {
+            return jsonReader.readArray();
+        } catch (final JsonException e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/adobe/aem/analyser/ApiRegionsMergeHandler.java
+++ b/src/main/java/com/adobe/aem/analyser/ApiRegionsMergeHandler.java
@@ -1,18 +1,19 @@
 package com.adobe.aem.analyser;
 
-import jakarta.json.*;
+import org.apache.sling.feature.extension.apiregions.api.ApiRegion;
+import org.apache.sling.feature.extension.apiregions.api.ApiExport;
+import org.apache.sling.feature.extension.apiregions.api.ApiRegions;
 
-import java.io.StringReader;
-import java.io.StringWriter;
+import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
  * Utility responsible for merging the {@code api-regions} JSON extension content.
  *
- * <p>The merge iterates over prerelease regions and keeps prerelease data by default.
- * For matching regions, stable {@code exports} are reused only when prerelease does not
- * provide exports (missing or empty array).</p>
+ * <p>The merge iterates over prerelease regions and keeps prerelease region-level data.
+ * For matching regions, {@code exports} are merged by package name, with prerelease
+ * exports taking precedence on conflicts.</p>
  */
 class ApiRegionsMergeHandler {
 
@@ -22,9 +23,9 @@ class ApiRegionsMergeHandler {
     /**
      * Merges two {@code api-regions} JSON arrays and returns the resulting JSON text.
      *
-     * <p>Prerelease content is the baseline. Stable {@code exports} are copied only for
-     * matching regions where prerelease exports are missing or empty. If either JSON input
-     * is blank, null, or cannot be parsed as an array, the method falls back to
+     * <p>Prerelease content is the baseline. For each prerelease region, exports from matching
+     * stable region are added first and then prerelease exports override by package name.
+     * If input cannot be parsed by Sling {@link ApiRegions} model, the method falls back to
      * {@code prereleaseJson} unchanged.</p>
      *
      * @param stableJson stable {@code api-regions} JSON array text
@@ -32,77 +33,39 @@ class ApiRegionsMergeHandler {
      * @return merged {@code api-regions} JSON array text, or {@code prereleaseJson} on fallback
      */
     static String merge(final String stableJson, final String prereleaseJson) {
-        final JsonArray stableRegions = parseJsonArray(stableJson);
-        final JsonArray prereleaseRegions = parseJsonArray(prereleaseJson);
-        if (stableRegions == null || prereleaseRegions == null) {
+        try {
+            final ApiRegions stableRegions = ApiRegions.parse(stableJson);
+            final ApiRegions prereleaseRegions = ApiRegions.parse(prereleaseJson);
+
+            final Map<String, ApiRegion> stableByName = new LinkedHashMap<>();
+            for (final ApiRegion stableRegion : stableRegions.listRegions()) {
+                stableByName.put(stableRegion.getName(), stableRegion);
+            }
+
+            final ApiRegions merged = new ApiRegions();
+            for (final ApiRegion prereleaseRegion : prereleaseRegions.listRegions()) {
+                final ApiRegion stableRegion = stableByName.get(prereleaseRegion.getName());
+                merged.add(mergeRegionExports(stableRegion, prereleaseRegion));
+            }
+
+            return merged.toJSON();
+        } catch (final IOException | RuntimeException e) {
             return prereleaseJson;
         }
-
-        final Map<String, JsonObject> stableRegionsByName = new LinkedHashMap<>();
-        for (final JsonValue regionVal : stableRegions) {
-            if (regionVal.getValueType() == JsonValue.ValueType.OBJECT) {
-                final JsonObject region = regionVal.asJsonObject();
-                final String regionName = region.getString("name", null);
-                if (regionName != null) {
-                    stableRegionsByName.put(regionName, region);
-                }
-            }
-        }
-
-        final JsonArrayBuilder mergedRegions = Json.createArrayBuilder();
-        for (final JsonValue regionVal : prereleaseRegions) {
-            if (regionVal.getValueType() != JsonValue.ValueType.OBJECT) {
-                mergedRegions.add(regionVal);
-                continue;
-            }
-
-            final JsonObject prereleaseRegion = regionVal.asJsonObject();
-            final String regionName = prereleaseRegion.getString("name", null);
-            final JsonObject stableRegion = stableRegionsByName.get(regionName);
-            if (regionName == null || stableRegion == null || !shouldUseStableExports(prereleaseRegion, stableRegion)) {
-                mergedRegions.add(prereleaseRegion);
-                continue;
-            }
-
-            final JsonObjectBuilder mergedRegion = Json.createObjectBuilder();
-            for (final Map.Entry<String, JsonValue> entry : prereleaseRegion.entrySet()) {
-                if (!"exports".equals(entry.getKey())) {
-                    mergedRegion.add(entry.getKey(), entry.getValue());
-                }
-            }
-            mergedRegion.add("exports", stableRegion.getJsonArray("exports"));
-            mergedRegions.add(mergedRegion);
-        }
-
-        final StringWriter writer = new StringWriter();
-        try (final JsonWriter jsonWriter = Json.createWriter(writer)) {
-            jsonWriter.writeArray(mergedRegions.build());
-        }
-        return writer.toString();
     }
 
-    private static boolean shouldUseStableExports(final JsonObject prereleaseRegion, final JsonObject stableRegion) {
-        final JsonArray stableExports = stableRegion.getJsonArray("exports");
-        if (stableExports == null || stableExports.isEmpty()) {
-            return false;
-        }
+    private static ApiRegion mergeRegionExports(final ApiRegion stableRegion, final ApiRegion prereleaseRegion) {
+        final ApiRegion mergedRegion = new ApiRegion(prereleaseRegion.getName());
+        mergedRegion.setFeatureOrigins(prereleaseRegion.getFeatureOrigins());
+        mergedRegion.getProperties().putAll(prereleaseRegion.getProperties());
 
-        if (!prereleaseRegion.containsKey("exports")) {
-            return true;
+        final Map<String, ApiExport> exportsByPackageName = new LinkedHashMap<>();
+        if (stableRegion != null) {
+            stableRegion.listExports().forEach(export -> exportsByPackageName.put(export.getName(), export));
         }
-        final JsonValue prereleaseExports = prereleaseRegion.get("exports");
-        return prereleaseExports.getValueType() == JsonValue.ValueType.ARRAY
-                && prereleaseExports.asJsonArray().isEmpty();
-    }
+        prereleaseRegion.listExports().forEach(export -> exportsByPackageName.put(export.getName(), export));
 
-    private static JsonArray parseJsonArray(final String json) {
-        if (json == null || json.isBlank()) {
-            return null;
-        }
-        try (final JsonReader jsonReader = Json.createReader(new StringReader(json))) {
-            return jsonReader.readArray();
-        } catch (final JsonException e) {
-            return null;
-        }
+        exportsByPackageName.values().forEach(mergedRegion::add);
+        return mergedRegion;
     }
 }

--- a/src/main/java/com/adobe/aem/analyser/ApiRegionsMergeHandler.java
+++ b/src/main/java/com/adobe/aem/analyser/ApiRegionsMergeHandler.java
@@ -3,6 +3,8 @@ package com.adobe.aem.analyser;
 import org.apache.sling.feature.extension.apiregions.api.ApiRegion;
 import org.apache.sling.feature.extension.apiregions.api.ApiExport;
 import org.apache.sling.feature.extension.apiregions.api.ApiRegions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.LinkedHashMap;
@@ -13,9 +15,12 @@ import java.util.Map;
  *
  * <p>The merge iterates over prerelease regions and keeps prerelease region-level data.
  * For matching regions, {@code exports} are merged by package name, with prerelease
- * exports taking precedence on conflicts.</p>
+ * exports taking precedence on conflicts. Regions available only in stable are appended
+ * unchanged after all prerelease regions.</p>
  */
 class ApiRegionsMergeHandler {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ApiRegionsMergeHandler.class);
 
     private ApiRegionsMergeHandler() {
     }
@@ -25,6 +30,7 @@ class ApiRegionsMergeHandler {
      *
      * <p>Prerelease content is the baseline. For each prerelease region, exports from matching
      * stable region are added first and then prerelease exports override by package name.
+     * Regions existing only in stable are appended at the end.
      * If input cannot be parsed by Sling {@link ApiRegions} model, the method falls back to
      * {@code prereleaseJson} unchanged.</p>
      *
@@ -44,12 +50,14 @@ class ApiRegionsMergeHandler {
 
             final ApiRegions merged = new ApiRegions();
             for (final ApiRegion prereleaseRegion : prereleaseRegions.listRegions()) {
-                final ApiRegion stableRegion = stableByName.get(prereleaseRegion.getName());
+                final ApiRegion stableRegion = stableByName.remove(prereleaseRegion.getName());
                 merged.add(mergeRegionExports(stableRegion, prereleaseRegion));
             }
+            stableByName.values().forEach(stableOnlyRegion -> merged.add(mergeRegionExports(null, stableOnlyRegion)));
 
             return merged.toJSON();
         } catch (final IOException | RuntimeException e) {
+            LOGGER.warn("Failed to merge api-regions JSON, falling back to prerelease JSON.", e);
             return prereleaseJson;
         }
     }

--- a/src/main/java/com/adobe/aem/analyser/AssemblyBasedFeatureConflictResolver.java
+++ b/src/main/java/com/adobe/aem/analyser/AssemblyBasedFeatureConflictResolver.java
@@ -23,6 +23,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -74,12 +75,15 @@ class AssemblyBasedFeatureConflictResolver implements FeatureConflictResolver {
         // Configurations: last assembled (prerelease) wins on property conflicts.
         builderContext.addConfigsOverrides(Collections.singletonMap("*", "MERGE_LATEST"));
 
-        // Variables: use prerelease values as explicit overrides to avoid IllegalStateException
-        // on duplicate keys with different values.
-        builderContext.addVariablesOverrides(new HashMap<>(prerelease.getVariables()));
+        // Variables: merge stable and prerelease, with prerelease overriding on conflicts.
+        Map<String, String> variablesOverrides = new HashMap<>(stable.getVariables());
+        variablesOverrides.putAll(prerelease.getVariables());
+        builderContext.addVariablesOverrides(variablesOverrides);
 
         // Framework properties: same treatment as variables.
-        builderContext.addFrameworkPropertiesOverrides(new HashMap<>(prerelease.getFrameworkProperties()));
+        Map<String, String> frameworkPropertiesOverrides = new HashMap<>(stable.getFrameworkProperties());
+        frameworkPropertiesOverrides.putAll(prerelease.getFrameworkProperties());
+        builderContext.addFrameworkPropertiesOverrides(frameworkPropertiesOverrides);
 
         // stable first → prerelease last: consistent with all override rules above.
         return FeatureBuilder.assemble(prerelease.getId(), builderContext, stable, prerelease);

--- a/src/main/java/com/adobe/aem/analyser/AssemblyBasedFeatureConflictResolver.java
+++ b/src/main/java/com/adobe/aem/analyser/AssemblyBasedFeatureConflictResolver.java
@@ -122,8 +122,6 @@ class AssemblyBasedFeatureConflictResolver implements FeatureConflictResolver {
                         targetEx.getArtifacts().clear();
                         sourceEx.getArtifacts().forEach(a -> targetEx.getArtifacts().add(a.copy(a.getId())));
                         break;
-                    default:
-                        break;
                 }
             }
         }

--- a/src/main/java/com/adobe/aem/analyser/AssemblyBasedFeatureConflictResolver.java
+++ b/src/main/java/com/adobe/aem/analyser/AssemblyBasedFeatureConflictResolver.java
@@ -102,6 +102,8 @@ class AssemblyBasedFeatureConflictResolver implements FeatureConflictResolver {
      */
     private static class PrereleaseWinsMergeHandler implements MergeHandler {
 
+        private static final Logger LOGGER = LoggerFactory.getLogger(PrereleaseWinsMergeHandler.class);
+
         @Override
         public boolean canMerge(final Extension extension) {
             return true;
@@ -122,6 +124,7 @@ class AssemblyBasedFeatureConflictResolver implements FeatureConflictResolver {
                         if (API_REGIONS_EXTENSION_NAME.equals(sourceEx.getName())) {
                             targetEx.setJSON(ApiRegionsMergeHandler.merge(targetEx.getJSON(), sourceEx.getJSON()));
                         } else {
+                            LOGGER.warn("Unsupported JSON extension {}. Using source JSON as fallback.", sourceEx.getName());
                             targetEx.setJSON(sourceEx.getJSON());
                         }
                         break;

--- a/src/main/java/com/adobe/aem/analyser/AssemblyBasedFeatureConflictResolver.java
+++ b/src/main/java/com/adobe/aem/analyser/AssemblyBasedFeatureConflictResolver.java
@@ -11,6 +11,7 @@
 */
 package com.adobe.aem.analyser;
 
+import org.apache.sling.feature.Artifact;
 import org.apache.sling.feature.ArtifactId;
 import org.apache.sling.feature.Extension;
 import org.apache.sling.feature.Feature;
@@ -23,7 +24,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.ServiceLoader;
 import java.util.Spliterator;
 import java.util.Spliterators;
@@ -123,11 +126,25 @@ class AssemblyBasedFeatureConflictResolver implements FeatureConflictResolver {
                         }
                         break;
                     case ARTIFACTS:
+                        final Map<String, Artifact> mergedArtifactsByKey = new LinkedHashMap<>();
+                        targetEx.getArtifacts().forEach(artifact ->
+                                mergedArtifactsByKey.put(toVersionlessKey(artifact.getId()), artifact));
+                        sourceEx.getArtifacts().forEach(artifact ->
+                                mergedArtifactsByKey.put(toVersionlessKey(artifact.getId()), artifact.copy(artifact.getId())));
+
                         targetEx.getArtifacts().clear();
-                        sourceEx.getArtifacts().forEach(a -> targetEx.getArtifacts().add(a.copy(a.getId())));
+                        targetEx.getArtifacts().addAll(mergedArtifactsByKey.values());
                         break;
                 }
             }
+        }
+
+        private static String toVersionlessKey(final ArtifactId artifactId) {
+            return String.join(":",
+                    artifactId.getGroupId(),
+                    artifactId.getArtifactId(),
+                    Objects.toString(artifactId.getType(), ""),
+                    Objects.toString(artifactId.getClassifier(), ""));
         }
     }
 }

--- a/src/main/java/com/adobe/aem/analyser/AssemblyBasedFeatureConflictResolver.java
+++ b/src/main/java/com/adobe/aem/analyser/AssemblyBasedFeatureConflictResolver.java
@@ -1,0 +1,131 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser;
+
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Extension;
+import org.apache.sling.feature.Feature;
+import org.apache.sling.feature.builder.BuilderContext;
+import org.apache.sling.feature.builder.FeatureBuilder;
+import org.apache.sling.feature.builder.HandlerContext;
+import org.apache.sling.feature.builder.MergeHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.ServiceLoader;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.StreamSupport;
+
+/**
+ * Feature conflict resolver that uses {@link FeatureBuilder#assemble} to merge two features,
+ * preferring prerelease artifacts, configurations, variables, framework properties and extensions
+ * over stable ones.
+ *
+ * <p>The assembly order is {@code stable} first, {@code prerelease} last. Override rules and a
+ * custom {@link MergeHandler} ensure that prerelease values win on every type of conflict.
+ * Data present only in stable is still carried over to the result.</p>
+ */
+class AssemblyBasedFeatureConflictResolver implements FeatureConflictResolver {
+
+    private static final String API_REGIONS_EXTENSION_NAME = "api-regions";
+    private static final Logger LOGGER = LoggerFactory.getLogger(AssemblyBasedFeatureConflictResolver.class);
+
+    @Override
+    public Feature resolveVersionConflict(final Feature stable, final Feature prerelease,
+                                          final SdkProductVariation variation) {
+        LOGGER.info("Resolving version conflict between {} and {} for {} using FeatureBuilder.assemble().",
+                stable.getId().toMvnId(), prerelease.getId().toMvnId(), variation);
+
+        final BuilderContext builderContext = new BuilderContext(id -> {
+            if (id.equals(stable.getId())) {
+                return stable;
+            }
+            if (id.equals(prerelease.getId())) {
+                return prerelease;
+            }
+            return null;
+        });
+
+        // Extensions: custom handler runs first and replaces target with source (prerelease wins).
+        // It handles all extension types so subsequent ServiceLoader handlers are not invoked.
+        builderContext.addMergeExtensions(new PrereleaseWinsMergeHandler());
+        builderContext.addMergeExtensions(StreamSupport.stream(
+                        Spliterators.spliteratorUnknownSize(
+                                ServiceLoader.load(MergeHandler.class).iterator(), Spliterator.ORDERED),
+                        false)
+                .toArray(MergeHandler[]::new));
+
+        // Artifacts: LATEST picks the last feature assembled (prerelease).
+        builderContext.addArtifactsOverride(ArtifactId.parse("*:*:LATEST"));
+        builderContext.addArtifactsOverride(ArtifactId.parse("*:*:*:*:LATEST"));
+
+        // Configurations: last assembled (prerelease) wins on property conflicts.
+        builderContext.addConfigsOverrides(Collections.singletonMap("*", "MERGE_LATEST"));
+
+        // Variables: use prerelease values as explicit overrides to avoid IllegalStateException
+        // on duplicate keys with different values.
+        builderContext.addVariablesOverrides(new HashMap<>(prerelease.getVariables()));
+
+        // Framework properties: same treatment as variables.
+        builderContext.addFrameworkPropertiesOverrides(new HashMap<>(prerelease.getFrameworkProperties()));
+
+        // stable first → prerelease last: consistent with all override rules above.
+        return FeatureBuilder.assemble(prerelease.getId(), builderContext, stable, prerelease);
+    }
+
+    /**
+     * {@link MergeHandler} that handles every extension type by replacing the target extension
+     * content with the source extension content. When no conflict exists (targetEx is null),
+     * the source extension is simply copied into the target feature.
+     *
+     * <p>Because this handler returns {@code true} for all extensions, it prevents any
+     * subsequently registered handler from running, giving it full control over extension merging.
+     */
+    private static class PrereleaseWinsMergeHandler implements MergeHandler {
+
+        @Override
+        public boolean canMerge(final Extension extension) {
+            return true;
+        }
+
+        @Override
+        public void merge(final HandlerContext context, final Feature target, final Feature source,
+                          final Extension targetEx, final Extension sourceEx) {
+            if (targetEx == null) {
+                target.getExtensions().add(sourceEx.copy());
+            } else {
+                // Source (prerelease) replaces target (stable).
+                switch (sourceEx.getType()) {
+                    case TEXT:
+                        targetEx.setText(sourceEx.getText());
+                        break;
+                    case JSON:
+                        if (API_REGIONS_EXTENSION_NAME.equals(sourceEx.getName())) {
+                            targetEx.setJSON(ApiRegionsMergeHandler.merge(targetEx.getJSON(), sourceEx.getJSON()));
+                        } else {
+                            targetEx.setJSON(sourceEx.getJSON());
+                        }
+                        break;
+                    case ARTIFACTS:
+                        targetEx.getArtifacts().clear();
+                        sourceEx.getArtifacts().forEach(a -> targetEx.getArtifacts().add(a.copy(a.getId())));
+                        break;
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/adobe/aem/analyser/FeatureConflictResolver.java
+++ b/src/main/java/com/adobe/aem/analyser/FeatureConflictResolver.java
@@ -1,0 +1,34 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser;
+
+import org.apache.sling.feature.Feature;
+
+/**
+ * Resolves conflicts when merging two features with the same version.
+ * The resolver decides how to handle duplicate bundles, configurations, and extensions.
+ */
+public interface FeatureConflictResolver {
+
+    /**
+     * Merge two features that have the same version.
+     * This method is called only when both features are available and have the same version.
+     * The resolver is responsible for deciding which artifacts take precedence in case of conflicts.
+     *
+     * @param stable the stable feature
+     * @param prerelease the prerelease feature (same version as stable)
+     * @param variation the product variation
+     * @return merged feature with conflicts resolved
+     */
+    Feature resolveVersionConflict(Feature stable, Feature prerelease,
+                                   SdkProductVariation variation);
+}

--- a/src/test/java/com/adobe/aem/analyser/AemSdkProductFeatureGeneratorTest.java
+++ b/src/test/java/com/adobe/aem/analyser/AemSdkProductFeatureGeneratorTest.java
@@ -11,22 +11,29 @@
 */
 package com.adobe.aem.analyser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.*;
-
+import com.adobe.aem.project.ServiceType;
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
-import org.apache.sling.feature.*;
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Configuration;
+import org.apache.sling.feature.Extension;
+import org.apache.sling.feature.ExtensionState;
+import org.apache.sling.feature.ExtensionType;
+import org.apache.sling.feature.Feature;
 import org.apache.sling.feature.builder.FeatureProvider;
 import org.junit.Test;
 
-import com.adobe.aem.project.ServiceType;
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 public class AemSdkProductFeatureGeneratorTest {
 

--- a/src/test/java/com/adobe/aem/analyser/AemSdkProductFeatureGeneratorTest.java
+++ b/src/test/java/com/adobe/aem/analyser/AemSdkProductFeatureGeneratorTest.java
@@ -12,15 +12,17 @@
 package com.adobe.aem.analyser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
+import java.io.StringReader;
+import java.util.*;
 
-import org.apache.sling.feature.ArtifactId;
-import org.apache.sling.feature.Feature;
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import org.apache.sling.feature.*;
 import org.apache.sling.feature.builder.FeatureProvider;
 import org.junit.Test;
 
@@ -33,7 +35,7 @@ public class AemSdkProductFeatureGeneratorTest {
         FeatureProvider fp = id -> new Feature(id);
 
         ArtifactId sdkID = ArtifactId.fromMvnId("foo:bar:123");
-        AemSdkProductFeatureGenerator pg = new AemSdkProductFeatureGenerator(fp, sdkID, Collections.emptyList());
+        AemSdkProductFeatureGenerator pg = new AemSdkProductFeatureGenerator(fp, sdkID, null, Collections.emptyList(), Collections.emptyList());
 
         Map<ProductVariation, List<Feature>> res = pg.getProductAggregates(EnumSet.of(ServiceType.AUTHOR));
         assertEquals(1, res.size());
@@ -49,7 +51,7 @@ public class AemSdkProductFeatureGeneratorTest {
 
         ArtifactId sdkID = ArtifactId.fromMvnId("foo:bar:123");
         ArtifactId addonID = ArtifactId.fromMvnId("my:testaddon:999");
-        AemSdkProductFeatureGenerator pg = new AemSdkProductFeatureGenerator(fp, sdkID, Collections.singletonList(addonID));
+        AemSdkProductFeatureGenerator pg = new AemSdkProductFeatureGenerator(fp, sdkID, null, Collections.singletonList(addonID), Collections.emptyList());
 
         Map<ProductVariation, List<Feature>> res = pg.getProductAggregates(EnumSet.allOf(ServiceType.class));
         assertEquals(2, res.size());
@@ -62,5 +64,443 @@ public class AemSdkProductFeatureGeneratorTest {
         assertEquals(2, flp.size());
         assertEquals("bar", flp.get(0).getId().getArtifactId());
         assertEquals("testaddon", flp.get(1).getId().getArtifactId());
+    }
+
+    /**
+     * Input:
+     * - stable SDK version is newer than prerelease SDK version
+     * - both SDK features contain bundles and api-regions extension
+     *
+     * Expected:
+     * - stable SDK feature is selected for AUTHOR aggregate
+     * - selected bundles and their versions come from stable
+     */
+    @Test
+    public void testGetProductAggregatesSelectsNewerStableOverPrerelease() throws IOException {
+        final ArtifactId stableSdkId = ArtifactId.fromMvnId("com.adobe.aem:aem-sdk-api:2.1.0");
+        final ArtifactId prereleaseSdkId = ArtifactId.fromMvnId("com.adobe.aem:aem-prerelease-sdk-api:2.0.0");
+
+
+        FeatureProvider fp = id -> {
+            if ("aem-sdk-api".equals(id.getArtifactId())) {
+                final Feature stable = new Feature(id);
+                stable.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:stable.bundle:2.1")));
+                stable.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:another.bundle:2.1")));
+                final Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+                stable.getExtensions().add(apiRegions);
+                return stable;
+            }
+            if ("aem-prerelease-sdk-api".equals(id.getArtifactId())) {
+                final Feature prerelease = new Feature(id);
+                prerelease.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:prerelease.bundle:2.0")));
+                prerelease.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:another.bundle:2.0")));
+                final Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+                prerelease.getExtensions().add(apiRegions);
+                return prerelease;
+            }
+            return new Feature(id);
+        };
+
+        AemSdkProductFeatureGenerator pg = new AemSdkProductFeatureGenerator(fp, stableSdkId, prereleaseSdkId,
+                null, null);
+        Map<ProductVariation, List<Feature>> res = pg.getProductAggregates(EnumSet.of(ServiceType.AUTHOR));
+
+        Feature productFeature = res.get(SdkProductVariation.AUTHOR).get(0);
+        assertEquals("aem-sdk-api", productFeature.getId().getArtifactId());
+        assertEquals("2.1.0", productFeature.getId().getVersion());
+        assertEquals(2, productFeature.getBundles().size());
+        assertNotNull(productFeature.getExtensions().getByName("api-regions"));
+
+        assertEquals("stable.bundle", productFeature.getBundles().get(0).getId().getArtifactId());
+        assertEquals("2.1", productFeature.getBundles().get(0).getId().getVersion());
+        assertEquals("another.bundle", productFeature.getBundles().get(1).getId().getArtifactId());
+        assertEquals("2.1", productFeature.getBundles().get(1).getId().getVersion());
+        assertNotNull(productFeature.getExtensions().getByName("api-regions"));
+    }
+
+    /**
+     * Input:
+     * - prerelease SDK version is newer than stable SDK version
+     * - both SDK features contain bundles and api-regions extension
+     *
+     * Expected:
+     * - prerelease SDK feature is selected for AUTHOR aggregate
+     * - selected bundles and versions come from prerelease
+     */
+    @Test
+    public void testGetProductAggregatesSelectsNewerPrereleaseOverStable() throws IOException {
+        final ArtifactId stableSdkId = ArtifactId.fromMvnId("com.adobe.aem:aem-sdk-api:2.0.0");
+        final ArtifactId prereleaseSdkId = ArtifactId.fromMvnId("com.adobe.aem:aem-prerelease-sdk-api:2.1.0");
+
+        FeatureProvider fp = id -> {
+            if ("aem-sdk-api".equals(id.getArtifactId())) {
+                final Feature stable = new Feature(id);
+                stable.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:stable.bundle:2.0")));
+                final Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+                stable.getExtensions().add(apiRegions);
+                return stable;
+            }
+
+            if ("aem-prerelease-sdk-api".equals(id.getArtifactId())) {
+                final Feature prerelease = new Feature(id);
+                prerelease.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:prerelease.bundle:2.1")));
+                prerelease.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:another.bundle:2.1")));
+                final Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+                prerelease.getExtensions().add(apiRegions);
+                return prerelease;
+            }
+            return new Feature(id);
+        };
+
+        AemSdkProductFeatureGenerator pg = new AemSdkProductFeatureGenerator(fp, stableSdkId, prereleaseSdkId,
+                null, null);
+        Map<ProductVariation, List<Feature>> res = pg.getProductAggregates(EnumSet.of(ServiceType.AUTHOR));
+
+        Feature productFeature = res.get(SdkProductVariation.AUTHOR).get(0);
+        assertEquals("aem-prerelease-sdk-api", productFeature.getId().getArtifactId());
+        assertEquals("2.1.0", productFeature.getId().getVersion());
+        assertEquals(2, productFeature.getBundles().size());
+
+        assertEquals("prerelease.bundle", productFeature.getBundles().get(0).getId().getArtifactId());
+        assertEquals("2.1", productFeature.getBundles().get(0).getId().getVersion());
+        assertEquals("another.bundle", productFeature.getBundles().get(1).getId().getArtifactId());
+        assertEquals("2.1", productFeature.getBundles().get(1).getId().getVersion());
+        assertNotNull(productFeature.getExtensions().getByName("api-regions"));
+    }
+
+    /**
+     * Input:
+     * - stable and prerelease SDK features have the same version
+     * - both define overlapping bundles/configurations/extensions with different values
+     *
+     * Expected:
+     * - conflict resolver is used
+     * - prerelease values are preferred for duplicates
+     * - non-duplicate stable data is preserved
+     */
+    @Test
+    public void testGetProductAggregatesResolvesSameVersionConflicts() throws IOException {
+        final ArtifactId stableSdkId = ArtifactId.fromMvnId("com.adobe.aem:aem-sdk-api:2.1.0");
+        final ArtifactId prereleaseSdkId = ArtifactId.fromMvnId("com.adobe.aem:aem-prerelease-sdk-api:2.1.0");
+
+        FeatureProvider fp = id -> {
+            if ("aem-sdk-api".equals(id.getArtifactId())) {
+                final Feature stable = new Feature(id);
+                stable.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:stable.bundle:1")));
+                stable.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:other.bundle:2")));
+
+                final Configuration stableConfig = new Configuration("stable.pid");
+                stableConfig.getProperties().put("source", "stable");
+                stable.getConfigurations().add(stableConfig);
+
+                final Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+                apiRegions.setJSON("{\"aa\": \"aa\"}");
+                stable.getExtensions().add(apiRegions);
+
+                final Extension other = new Extension(ExtensionType.TEXT, "other-ext", ExtensionState.OPTIONAL);
+                other.setText("stable-other-ext-content");
+                stable.getExtensions().add(other);
+                return stable;
+            }
+            if ("aem-prerelease-sdk-api".equals(id.getArtifactId())) {
+                final Feature stable = new Feature(id);
+                stable.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:prerelease.bundle:1")));
+                stable.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:other.bundle:1")));
+
+                final Configuration stableConfig = new Configuration("stable.pid");
+                stableConfig.getProperties().put("source", "prerelease");
+                stable.getConfigurations().add(stableConfig);
+
+                final Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+                apiRegions.setJSON("{\"aa\": \"bb\"}");
+                stable.getExtensions().add(apiRegions);
+
+                final Extension other = new Extension(ExtensionType.TEXT, "other-ext", ExtensionState.OPTIONAL);
+                other.setText("prerelease-other-ext-content");
+                stable.getExtensions().add(other);
+                return stable;
+            }
+
+            return new Feature(id);
+        };
+
+        AemSdkProductFeatureGenerator pg = new AemSdkProductFeatureGenerator(
+                fp,
+                stableSdkId,
+                prereleaseSdkId,
+                null,
+                Collections.emptyList());
+
+        Map<ProductVariation, List<Feature>> res = pg.getProductAggregates(EnumSet.of(ServiceType.AUTHOR));
+        List<Feature> features = res.get(SdkProductVariation.AUTHOR);
+
+        assertEquals(1, features.size());
+
+        Feature sdkFeature = features.get(0);
+        assertEquals("aem-prerelease-sdk-api", sdkFeature.getId().getArtifactId());
+
+        assertEquals(3, sdkFeature.getBundles().size());
+        assertEquals("stable.bundle", sdkFeature.getBundles().get(0).getId().getArtifactId());
+        assertEquals("other.bundle", sdkFeature.getBundles().get(1).getId().getArtifactId());
+        assertEquals("prerelease.bundle", sdkFeature.getBundles().get(2).getId().getArtifactId());
+
+        assertEquals(1, sdkFeature.getConfigurations().size());
+        Configuration config = sdkFeature.getConfigurations().iterator().next();
+        assertEquals("stable.pid", config.getPid());
+        assertEquals("prerelease", config.getProperties().get("source"));
+
+        Extension apiRegionsExt = sdkFeature.getExtensions().getByName("api-regions");
+        assertEquals("{\"aa\": \"bb\"}", apiRegionsExt.getJSON());
+        assertEquals(ExtensionType.JSON, apiRegionsExt.getType());
+
+        Extension otherExt = sdkFeature.getExtensions().getByName("other-ext");
+        assertNotNull(otherExt);
+        assertEquals(ExtensionType.TEXT, otherExt.getType());
+        assertEquals("prerelease-other-ext-content", otherExt.getText());
+    }
+
+    /**
+     * Input:
+     * - stable add-on version is newer than prerelease add-on version
+     * - both add-on counterparts are available for the same logical add-on
+     *
+     * Expected:
+     * - stable add-on feature is selected
+     * - selected add-on bundles/configurations are from stable
+     */
+    @Test
+    public void testGetAddOnSelectsNewerStableOverPrerelease() throws IOException {
+        final ArtifactId stableAddonId = ArtifactId.fromMvnId("com.adobe.aem:aem-addon:2.1.0");
+        final ArtifactId prereleaseAddonId = ArtifactId.fromMvnId("com.adobe.aem:aem-addon-prerelease:2.0.0");
+
+        FeatureProvider fp = id -> {
+            if ("aem-addon".equals(id.getArtifactId())) {
+                final Feature stable = new Feature(id);
+                stable.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:stable.addon.bundle:2.1")));
+                stable.getConfigurations().add(new Configuration("addon.stable.pid"));
+                return stable;
+            }
+            if ("aem-addon-prerelease".equals(id.getArtifactId())) {
+                final Feature prerelease = new Feature(id);
+                prerelease.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:prerelease.addon.bundle:2.0")));
+                return prerelease;
+            }
+            return new Feature(id);
+        };
+
+        AemSdkProductFeatureGenerator pg = new AemSdkProductFeatureGenerator(
+                fp,
+                ArtifactId.fromMvnId("com.adobe.aem:aem-sdk-api:1.0.0"),
+                null,
+                Collections.singletonList(stableAddonId),
+                Collections.singletonList(prereleaseAddonId));
+
+        Map<ProductVariation, List<Feature>> res = pg.getProductAggregates(EnumSet.of(ServiceType.AUTHOR));
+        List<Feature> features = res.get(SdkProductVariation.AUTHOR);
+
+        assertEquals(2, features.size());
+        Feature addon = features.get(1);
+        assertEquals("aem-addon", addon.getId().getArtifactId());
+        assertEquals("2.1.0", addon.getId().getVersion());
+        assertEquals(1, addon.getBundles().size());
+        assertEquals("stable.addon.bundle", addon.getBundles().get(0).getId().getArtifactId());
+        assertEquals(1, addon.getConfigurations().size());
+    }
+
+    /**
+     * Input:
+     * - prerelease add-on version is newer than stable add-on version
+     * - both add-on counterparts are available for the same logical add-on
+     *
+     * Expected:
+     * - prerelease add-on feature is selected
+     * - selected add-on bundles/configurations are from prerelease
+     */
+    @Test
+    public void testGetAddOnSelectsNewerPrereleaseOverStable() throws IOException {
+        final ArtifactId stableAddonId = ArtifactId.fromMvnId("com.adobe.aem:aem-addon:2.0.0");
+        final ArtifactId prereleaseAddonId = ArtifactId.fromMvnId("com.adobe.aem:aem-addon-prerelease:2.1.0");
+
+        FeatureProvider fp = id -> {
+            if ("aem-addon".equals(id.getArtifactId())) {
+                final Feature stable = new Feature(id);
+                stable.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:stable.addon.bundle:2.0")));
+                return stable;
+            }
+            if ("aem-addon-prerelease".equals(id.getArtifactId())) {
+                final Feature prerelease = new Feature(id);
+                prerelease.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:prerelease.addon.bundle:2.1")));
+                prerelease.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:another.addon.bundle:2.1")));
+                prerelease.getConfigurations().add(new Configuration("addon.prerelease.pid"));
+                return prerelease;
+            }
+            return new Feature(id);
+        };
+
+        AemSdkProductFeatureGenerator pg = new AemSdkProductFeatureGenerator(
+                fp,
+                ArtifactId.fromMvnId("com.adobe.aem:aem-sdk-api:1.0.0"),
+                null,
+                Collections.singletonList(stableAddonId),
+                Collections.singletonList(prereleaseAddonId));
+
+        Map<ProductVariation, List<Feature>> res = pg.getProductAggregates(EnumSet.of(ServiceType.AUTHOR));
+        List<Feature> features = res.get(SdkProductVariation.AUTHOR);
+
+        assertEquals(2, features.size());
+        Feature addon = features.get(1);
+        assertEquals("aem-addon-prerelease", addon.getId().getArtifactId());
+        assertEquals("2.1.0", addon.getId().getVersion());
+        assertEquals(2, addon.getBundles().size());
+        assertEquals("prerelease.addon.bundle", addon.getBundles().get(0).getId().getArtifactId());
+        assertEquals("another.addon.bundle", addon.getBundles().get(1).getId().getArtifactId());
+        assertEquals(1, addon.getConfigurations().size());
+    }
+
+    /**
+     * Input:
+     * - stable and prerelease add-on features have the same version
+     * - both contain overlapping bundles/configurations/extensions with different values
+     *
+     * Expected:
+     * - add-on conflict resolver is used
+     * - prerelease values are preferred for duplicates
+     * - non-duplicate stable add-on data remains in result
+     */
+    @Test
+    public void testGetAddOnResolvesSameVersionConflict() throws IOException {
+        final ArtifactId stableAddonId = ArtifactId.fromMvnId("com.adobe.aem:aem-addon:1.5.0");
+        final ArtifactId prereleaseAddonId = ArtifactId.fromMvnId("com.adobe.aem:aem-addon-prerelease:1.5.0");
+
+        FeatureProvider fp = id -> {
+            if ("aem-addon".equals(id.getArtifactId())) {
+                final Feature stable = new Feature(id);
+                stable.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:stable.addon.bundle:1")));
+                stable.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:shared.addon.bundle:2")));
+
+                final Configuration stableConfig = new Configuration("addon.pid");
+                stableConfig.getProperties().put("addon.source", "stable");
+                stable.getConfigurations().add(stableConfig);
+
+                final Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+                apiRegions.setJSON("{\"aa\": \"aa\"}");
+                stable.getExtensions().add(apiRegions);
+
+                final Extension other = new Extension(ExtensionType.TEXT, "other-ext", ExtensionState.OPTIONAL);
+                other.setText("stable-other-ext-content");
+                stable.getExtensions().add(other);
+                return stable;
+            }
+            if ("aem-addon-prerelease".equals(id.getArtifactId())) {
+                final Feature prerelease = new Feature(id);
+                prerelease.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:prerelease.addon.bundle:1")));
+                prerelease.getBundles().add(new org.apache.sling.feature.Artifact(ArtifactId.fromMvnId("g:shared.addon.bundle:1")));
+
+                final Configuration prereleaseConfig = new Configuration("addon.pid");
+                prereleaseConfig.getProperties().put("addon.source", "prerelease");
+                prerelease.getConfigurations().add(prereleaseConfig);
+
+                final Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+                apiRegions.setJSON("{\"aa\": \"bb\"}");
+                prerelease.getExtensions().add(apiRegions);
+
+                final Extension other = new Extension(ExtensionType.TEXT, "other-ext", ExtensionState.OPTIONAL);
+                other.setText("prerelease-other-ext-content");
+                prerelease.getExtensions().add(other);
+                return prerelease;
+            }
+            return new Feature(id);
+        };
+
+        AemSdkProductFeatureGenerator pg = new AemSdkProductFeatureGenerator(
+                fp,
+                ArtifactId.fromMvnId("com.adobe.aem:aem-sdk-api:1.0.0"),
+                null,
+                Collections.singletonList(stableAddonId),
+                Collections.singletonList(prereleaseAddonId));
+
+        Map<ProductVariation, List<Feature>> res = pg.getProductAggregates(EnumSet.of(ServiceType.AUTHOR));
+        List<Feature> features = res.get(SdkProductVariation.AUTHOR);
+
+        assertEquals(2, features.size());
+        Feature addon = features.get(1);
+        assertEquals("aem-addon-prerelease", addon.getId().getArtifactId());
+        assertEquals("1.5.0", addon.getId().getVersion());
+
+        assertEquals(3, addon.getBundles().size());
+        assertEquals("stable.addon.bundle", addon.getBundles().get(0).getId().getArtifactId());
+        assertEquals("1", addon.getBundles().get(0).getId().getVersion());
+        assertEquals("shared.addon.bundle", addon.getBundles().get(1).getId().getArtifactId());
+        assertEquals("1", addon.getBundles().get(1).getId().getVersion());
+        assertEquals("prerelease.addon.bundle", addon.getBundles().get(2).getId().getArtifactId());
+        assertEquals("1", addon.getBundles().get(2).getId().getVersion());
+
+        assertEquals(1, addon.getConfigurations().size());
+        Configuration config = addon.getConfigurations().iterator().next();
+        assertEquals("addon.pid", config.getPid());
+        assertEquals("prerelease", config.getProperties().get("addon.source"));
+
+        Extension apiRegionsExt = addon.getExtensions().getByName("api-regions");
+        assertEquals("{\"aa\": \"bb\"}", apiRegionsExt.getJSON());
+        assertEquals(ExtensionType.JSON, apiRegionsExt.getType());
+
+        Extension otherExt = addon.getExtensions().getByName("other-ext");
+        assertNotNull(otherExt);
+        assertEquals(ExtensionType.TEXT, otherExt.getType());
+        assertEquals("prerelease-other-ext-content", otherExt.getText());
+    }
+
+    @Test
+    public void testGetProductAggregatesUsesStableApiRegionsExportsWhenPrereleaseRegionIsEmpty() throws IOException {
+        final ArtifactId stableSdkId = ArtifactId.fromMvnId("com.adobe.aem:aem-sdk-api:2.1.0");
+        final ArtifactId prereleaseSdkId = ArtifactId.fromMvnId("com.adobe.aem:aem-prerelease-sdk-api:2.1.0");
+
+        FeatureProvider fp = id -> {
+            if ("aem-sdk-api".equals(id.getArtifactId())) {
+                final Feature stable = new Feature(id);
+                final Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+                apiRegions.setJSON("[{\"name\":\"global\",\"exports\":[{\"name\":\"ch.qos.logback.classic\",\"deprecated\":{\"msg\":\"This internal logback API is not supported by AEM as a Cloud Service.\",\"since\":\"2022-01-27\",\"for-removal\":\"2025-08-31\"}}]},{\"name\":\"com.adobe.aem.deprecated\",\"exports\":[{\"name\":\"org.apache.abdera.ext.opensearch\",\"deprecated\":{\"msg\":\"Legacy AEM 6.x API.\",\"since\":\"2019-04-08\",\"for-removal\":\"2025-08-31\"}}]}]");
+                stable.getExtensions().add(apiRegions);
+                return stable;
+            }
+            if ("aem-prerelease-sdk-api".equals(id.getArtifactId())) {
+                final Feature prerelease = new Feature(id);
+                final Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+                apiRegions.setJSON("[{\"name\":\"global\"},{\"name\":\"com.adobe.aem.deprecated\"}]");
+                prerelease.getExtensions().add(apiRegions);
+                return prerelease;
+            }
+            return new Feature(id);
+        };
+
+        AemSdkProductFeatureGenerator pg = new AemSdkProductFeatureGenerator(
+                fp,
+                stableSdkId,
+                prereleaseSdkId,
+                null,
+                Collections.emptyList(),
+                new AssemblyBasedFeatureConflictResolver());
+
+        Map<ProductVariation, List<Feature>> res = pg.getProductAggregates(EnumSet.of(ServiceType.AUTHOR));
+        Feature sdkFeature = res.get(SdkProductVariation.AUTHOR).get(0);
+
+        Extension apiRegionsExt = sdkFeature.getExtensions().getByName("api-regions");
+        assertNotNull(apiRegionsExt);
+        assertEquals(ExtensionType.JSON, apiRegionsExt.getType());
+
+        JsonArray regions = Json.createReader(new StringReader(apiRegionsExt.getJSON())).readArray();
+        JsonObject globalRegion = regions.getJsonObject(0);
+        JsonObject deprecatedRegion = regions.getJsonObject(1);
+
+        assertTrue(globalRegion.containsKey("exports"));
+        assertEquals("ch.qos.logback.classic",
+                globalRegion.getJsonArray("exports").getJsonObject(0).getString("name"));
+        assertEquals("2025-08-31",
+                globalRegion.getJsonArray("exports").getJsonObject(0)
+                        .getJsonObject("deprecated").getString("for-removal"));
+
+        assertTrue(deprecatedRegion.containsKey("exports"));
+        assertEquals("org.apache.abdera.ext.opensearch",
+                deprecatedRegion.getJsonArray("exports").getJsonObject(0).getString("name"));
     }
 }

--- a/src/test/java/com/adobe/aem/analyser/AemSdkProductFeatureGeneratorTest.java
+++ b/src/test/java/com/adobe/aem/analyser/AemSdkProductFeatureGeneratorTest.java
@@ -11,7 +11,17 @@
 */
 package com.adobe.aem.analyser;
 
-import com.adobe.aem.project.ServiceType;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
 import jakarta.json.Json;
 import jakarta.json.JsonArray;
 import jakarta.json.JsonObject;
@@ -24,16 +34,7 @@ import org.apache.sling.feature.Feature;
 import org.apache.sling.feature.builder.FeatureProvider;
 import org.junit.Test;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.util.Collections;
-import java.util.EnumSet;
-import java.util.List;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import com.adobe.aem.project.ServiceType;
 
 public class AemSdkProductFeatureGeneratorTest {
 

--- a/src/test/java/com/adobe/aem/analyser/AemSdkProductFeatureGeneratorTest.java
+++ b/src/test/java/com/adobe/aem/analyser/AemSdkProductFeatureGeneratorTest.java
@@ -13,18 +13,13 @@ package com.adobe.aem.analyser;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.io.StringReader;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 
-import jakarta.json.Json;
-import jakarta.json.JsonArray;
-import jakarta.json.JsonObject;
 import org.apache.sling.feature.ArtifactId;
 import org.apache.sling.feature.Configuration;
 import org.apache.sling.feature.Extension;
@@ -132,11 +127,11 @@ public class AemSdkProductFeatureGeneratorTest {
      * - both SDK features contain bundles and api-regions extension
      *
      * Expected:
-     * - prerelease SDK feature is selected for AUTHOR aggregate
-     * - selected bundles and versions come from prerelease
+     * - stable SDK feature is selected for AUTHOR aggregate
+     * - selected bundle comes from stable
      */
     @Test
-    public void testGetProductAggregatesSelectsNewerPrereleaseOverStable() throws IOException {
+    public void testGetProductAggregatesSelectsStableOverNewerPrerelease() throws IOException {
         final ArtifactId stableSdkId = ArtifactId.fromMvnId("com.adobe.aem:aem-sdk-api:2.0.0");
         final ArtifactId prereleaseSdkId = ArtifactId.fromMvnId("com.adobe.aem:aem-prerelease-sdk-api:2.1.0");
 
@@ -165,14 +160,12 @@ public class AemSdkProductFeatureGeneratorTest {
         Map<ProductVariation, List<Feature>> res = pg.getProductAggregates(EnumSet.of(ServiceType.AUTHOR));
 
         Feature productFeature = res.get(SdkProductVariation.AUTHOR).get(0);
-        assertEquals("aem-prerelease-sdk-api", productFeature.getId().getArtifactId());
-        assertEquals("2.1.0", productFeature.getId().getVersion());
-        assertEquals(2, productFeature.getBundles().size());
+        assertEquals("aem-sdk-api", productFeature.getId().getArtifactId());
+        assertEquals("2.0.0", productFeature.getId().getVersion());
+        assertEquals(1, productFeature.getBundles().size());
 
-        assertEquals("prerelease.bundle", productFeature.getBundles().get(0).getId().getArtifactId());
-        assertEquals("2.1", productFeature.getBundles().get(0).getId().getVersion());
-        assertEquals("another.bundle", productFeature.getBundles().get(1).getId().getArtifactId());
-        assertEquals("2.1", productFeature.getBundles().get(1).getId().getVersion());
+        assertEquals("stable.bundle", productFeature.getBundles().get(0).getId().getArtifactId());
+        assertEquals("2.0", productFeature.getBundles().get(0).getId().getVersion());
         assertNotNull(productFeature.getExtensions().getByName("api-regions"));
     }
 
@@ -321,11 +314,11 @@ public class AemSdkProductFeatureGeneratorTest {
      * - both add-on counterparts are available for the same logical add-on
      *
      * Expected:
-     * - prerelease add-on feature is selected
-     * - selected add-on bundles/configurations are from prerelease
+     * - stable add-on feature is selected
+     * - selected add-on bundle is from stable
      */
     @Test
-    public void testGetAddOnSelectsNewerPrereleaseOverStable() throws IOException {
+    public void testGetAddOnSelectsStableOverNewerPrerelease() throws IOException {
         final ArtifactId stableAddonId = ArtifactId.fromMvnId("com.adobe.aem:aem-addon:2.0.0");
         final ArtifactId prereleaseAddonId = ArtifactId.fromMvnId("com.adobe.aem:aem-addon-prerelease:2.1.0");
 
@@ -357,12 +350,10 @@ public class AemSdkProductFeatureGeneratorTest {
 
         assertEquals(2, features.size());
         Feature addon = features.get(1);
-        assertEquals("aem-addon-prerelease", addon.getId().getArtifactId());
-        assertEquals("2.1.0", addon.getId().getVersion());
-        assertEquals(2, addon.getBundles().size());
-        assertEquals("prerelease.addon.bundle", addon.getBundles().get(0).getId().getArtifactId());
-        assertEquals("another.addon.bundle", addon.getBundles().get(1).getId().getArtifactId());
-        assertEquals(1, addon.getConfigurations().size());
+        assertEquals("aem-addon", addon.getId().getArtifactId());
+        assertEquals("2.0.0", addon.getId().getVersion());
+        assertEquals(1, addon.getBundles().size());
+        assertEquals("stable.addon.bundle", addon.getBundles().get(0).getId().getArtifactId());
     }
 
     /**
@@ -456,59 +447,5 @@ public class AemSdkProductFeatureGeneratorTest {
         assertNotNull(otherExt);
         assertEquals(ExtensionType.TEXT, otherExt.getType());
         assertEquals("prerelease-other-ext-content", otherExt.getText());
-    }
-
-    @Test
-    public void testGetProductAggregatesUsesStableApiRegionsExportsWhenPrereleaseRegionIsEmpty() throws IOException {
-        final ArtifactId stableSdkId = ArtifactId.fromMvnId("com.adobe.aem:aem-sdk-api:2.1.0");
-        final ArtifactId prereleaseSdkId = ArtifactId.fromMvnId("com.adobe.aem:aem-prerelease-sdk-api:2.1.0");
-
-        FeatureProvider fp = id -> {
-            if ("aem-sdk-api".equals(id.getArtifactId())) {
-                final Feature stable = new Feature(id);
-                final Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
-                apiRegions.setJSON("[{\"name\":\"global\",\"exports\":[{\"name\":\"ch.qos.logback.classic\",\"deprecated\":{\"msg\":\"This internal logback API is not supported by AEM as a Cloud Service.\",\"since\":\"2022-01-27\",\"for-removal\":\"2025-08-31\"}}]},{\"name\":\"com.adobe.aem.deprecated\",\"exports\":[{\"name\":\"org.apache.abdera.ext.opensearch\",\"deprecated\":{\"msg\":\"Legacy AEM 6.x API.\",\"since\":\"2019-04-08\",\"for-removal\":\"2025-08-31\"}}]}]");
-                stable.getExtensions().add(apiRegions);
-                return stable;
-            }
-            if ("aem-prerelease-sdk-api".equals(id.getArtifactId())) {
-                final Feature prerelease = new Feature(id);
-                final Extension apiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
-                apiRegions.setJSON("[{\"name\":\"global\"},{\"name\":\"com.adobe.aem.deprecated\"}]");
-                prerelease.getExtensions().add(apiRegions);
-                return prerelease;
-            }
-            return new Feature(id);
-        };
-
-        AemSdkProductFeatureGenerator pg = new AemSdkProductFeatureGenerator(
-                fp,
-                stableSdkId,
-                prereleaseSdkId,
-                null,
-                Collections.emptyList(),
-                new AssemblyBasedFeatureConflictResolver());
-
-        Map<ProductVariation, List<Feature>> res = pg.getProductAggregates(EnumSet.of(ServiceType.AUTHOR));
-        Feature sdkFeature = res.get(SdkProductVariation.AUTHOR).get(0);
-
-        Extension apiRegionsExt = sdkFeature.getExtensions().getByName("api-regions");
-        assertNotNull(apiRegionsExt);
-        assertEquals(ExtensionType.JSON, apiRegionsExt.getType());
-
-        JsonArray regions = Json.createReader(new StringReader(apiRegionsExt.getJSON())).readArray();
-        JsonObject globalRegion = regions.getJsonObject(0);
-        JsonObject deprecatedRegion = regions.getJsonObject(1);
-
-        assertTrue(globalRegion.containsKey("exports"));
-        assertEquals("ch.qos.logback.classic",
-                globalRegion.getJsonArray("exports").getJsonObject(0).getString("name"));
-        assertEquals("2025-08-31",
-                globalRegion.getJsonArray("exports").getJsonObject(0)
-                        .getJsonObject("deprecated").getString("for-removal"));
-
-        assertTrue(deprecatedRegion.containsKey("exports"));
-        assertEquals("org.apache.abdera.ext.opensearch",
-                deprecatedRegion.getJsonArray("exports").getJsonObject(0).getString("name"));
     }
 }

--- a/src/test/java/com/adobe/aem/analyser/AemSdkProductFeatureGeneratorTest.java
+++ b/src/test/java/com/adobe/aem/analyser/AemSdkProductFeatureGeneratorTest.java
@@ -201,6 +201,11 @@ public class AemSdkProductFeatureGeneratorTest {
                 final Extension other = new Extension(ExtensionType.TEXT, "other-ext", ExtensionState.OPTIONAL);
                 other.setText("stable-other-ext-content");
                 stable.getExtensions().add(other);
+
+                stable.getVariables().put("var.only.stable", "stable.value");
+                stable.getVariables().put("var.common", "stable.value");
+                stable.getFrameworkProperties().put("fw.only.stable", "stable.fw.value");
+                stable.getFrameworkProperties().put("fw.common", "stable.fw.value");
                 return stable;
             }
             if ("aem-prerelease-sdk-api".equals(id.getArtifactId())) {
@@ -219,6 +224,11 @@ public class AemSdkProductFeatureGeneratorTest {
                 final Extension other = new Extension(ExtensionType.TEXT, "other-ext", ExtensionState.OPTIONAL);
                 other.setText("prerelease-other-ext-content");
                 stable.getExtensions().add(other);
+
+                stable.getVariables().put("var.only.prerelease", "prerelease.value");
+                stable.getVariables().put("var.common", "prerelease.value");
+                stable.getFrameworkProperties().put("fw.only.prerelease", "prerelease.fw.value");
+                stable.getFrameworkProperties().put("fw.common", "prerelease.fw.value");
                 return stable;
             }
 
@@ -258,6 +268,16 @@ public class AemSdkProductFeatureGeneratorTest {
         assertNotNull(otherExt);
         assertEquals(ExtensionType.TEXT, otherExt.getType());
         assertEquals("prerelease-other-ext-content", otherExt.getText());
+
+        assertEquals(3, sdkFeature.getVariables().size());
+        assertEquals("stable.value", sdkFeature.getVariables().get("var.only.stable"));
+        assertEquals("prerelease.value", sdkFeature.getVariables().get("var.common"));
+        assertEquals("prerelease.value", sdkFeature.getVariables().get("var.only.prerelease"));
+
+        assertEquals(3, sdkFeature.getFrameworkProperties().size());
+        assertEquals("stable.fw.value", sdkFeature.getFrameworkProperties().get("fw.only.stable"));
+        assertEquals("prerelease.fw.value", sdkFeature.getFrameworkProperties().get("fw.common"));
+        assertEquals("prerelease.fw.value", sdkFeature.getFrameworkProperties().get("fw.only.prerelease"));
     }
 
     /**
@@ -388,6 +408,11 @@ public class AemSdkProductFeatureGeneratorTest {
                 final Extension other = new Extension(ExtensionType.TEXT, "other-ext", ExtensionState.OPTIONAL);
                 other.setText("stable-other-ext-content");
                 stable.getExtensions().add(other);
+
+                stable.getVariables().put("addon.var.only.stable", "stable.addon.value");
+                stable.getVariables().put("addon.var.common", "stable.addon.value");
+                stable.getFrameworkProperties().put("addon.fw.only.stable", "stable.addon.fw.value");
+                stable.getFrameworkProperties().put("addon.fw.common", "stable.addon.fw.value");
                 return stable;
             }
             if ("aem-addon-prerelease".equals(id.getArtifactId())) {
@@ -406,6 +431,11 @@ public class AemSdkProductFeatureGeneratorTest {
                 final Extension other = new Extension(ExtensionType.TEXT, "other-ext", ExtensionState.OPTIONAL);
                 other.setText("prerelease-other-ext-content");
                 prerelease.getExtensions().add(other);
+
+                prerelease.getVariables().put("addon.var.only.prerelease", "prerelease.addon.value");
+                prerelease.getVariables().put("addon.var.common", "prerelease.addon.value");
+                prerelease.getFrameworkProperties().put("addon.fw.only.prerelease", "prerelease.addon.fw.value");
+                prerelease.getFrameworkProperties().put("addon.fw.common", "prerelease.addon.fw.value");
                 return prerelease;
             }
             return new Feature(id);
@@ -447,5 +477,15 @@ public class AemSdkProductFeatureGeneratorTest {
         assertNotNull(otherExt);
         assertEquals(ExtensionType.TEXT, otherExt.getType());
         assertEquals("prerelease-other-ext-content", otherExt.getText());
+
+        assertEquals(3, addon.getVariables().size());
+        assertEquals("stable.addon.value", addon.getVariables().get("addon.var.only.stable"));
+        assertEquals("prerelease.addon.value", addon.getVariables().get("addon.var.common"));
+        assertEquals("prerelease.addon.value", addon.getVariables().get("addon.var.only.prerelease"));
+
+        assertEquals(3, addon.getFrameworkProperties().size());
+        assertEquals("stable.addon.fw.value", addon.getFrameworkProperties().get("addon.fw.only.stable"));
+        assertEquals("prerelease.addon.fw.value", addon.getFrameworkProperties().get("addon.fw.common"));
+        assertEquals("prerelease.addon.fw.value", addon.getFrameworkProperties().get("addon.fw.only.prerelease"));
     }
 }

--- a/src/test/java/com/adobe/aem/analyser/ApiRegionsMergeHandlerTest.java
+++ b/src/test/java/com/adobe/aem/analyser/ApiRegionsMergeHandlerTest.java
@@ -1,0 +1,97 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+ */
+package com.adobe.aem.analyser;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+import jakarta.json.JsonValue;
+import org.junit.Test;
+
+import java.io.StringReader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+
+public class ApiRegionsMergeHandlerTest {
+
+    @Test
+    public void testMergeUsesStableExportsWhenPrereleaseExportsMissing() {
+        final String stableJson = "[{\"name\":\"global\",\"exports\":[\"a.b\"]}]";
+        final String prereleaseJson = "[{\"name\":\"global\",\"imports\":[\"x.y\"]}]";
+
+        final JsonObject mergedRegion = firstObjectRegion(ApiRegionsMergeHandler.merge(stableJson, prereleaseJson));
+
+        assertEquals("a.b", mergedRegion.getJsonArray("exports").getString(0));
+        assertEquals("x.y", mergedRegion.getJsonArray("imports").getString(0));
+    }
+
+    @Test
+    public void testMergeUsesStableExportsWhenPrereleaseExportsEmpty() {
+        final String stableJson = "[{\"name\":\"global\",\"exports\":[\"a.b\"]}]";
+        final String prereleaseJson = "[{\"name\":\"global\",\"exports\":[]}]";
+
+        final JsonObject mergedRegion = firstObjectRegion(ApiRegionsMergeHandler.merge(stableJson, prereleaseJson));
+
+        assertEquals("a.b", mergedRegion.getJsonArray("exports").getString(0));
+    }
+
+    @Test
+    public void testMergeKeepsPrereleaseExportsWhenNonEmpty() {
+        final String stableJson = "[{\"name\":\"global\",\"exports\":[\"stable.api\"]}]";
+        final String prereleaseJson = "[{\"name\":\"global\",\"exports\":[\"prerelease.api\"]}]";
+
+        final JsonObject mergedRegion = firstObjectRegion(ApiRegionsMergeHandler.merge(stableJson, prereleaseJson));
+
+        assertEquals("prerelease.api", mergedRegion.getJsonArray("exports").getString(0));
+    }
+
+    @Test
+    public void testMergeKeepsUnnamedRegionUnchanged() {
+        final String stableJson = "[{\"name\":\"global\",\"exports\":[\"stable.api\"]}]";
+        final String prereleaseJson = "[{\"exports\":[]}]";
+
+        final JsonObject mergedRegion = firstObjectRegion(ApiRegionsMergeHandler.merge(stableJson, prereleaseJson));
+
+        assertFalse(mergedRegion.containsKey("name"));
+        assertEquals(0, mergedRegion.getJsonArray("exports").size());
+    }
+
+    @Test
+    public void testMergeReturnsPrereleaseWhenStableJsonBlank() {
+        final String prereleaseJson = "[{\"name\":\"global\",\"exports\":[\"prerelease.api\"]}]";
+
+        assertEquals(prereleaseJson, ApiRegionsMergeHandler.merge("   ", prereleaseJson));
+    }
+
+    @Test
+    public void testMergeReturnsPrereleaseWhenStableJsonIsNotArray() {
+        final String stableJson = "{\"aa\":\"aa\"}";
+        final String prereleaseJson = "[{\"name\":\"global\",\"exports\":[\"prerelease.api\"]}]";
+
+        assertEquals(prereleaseJson, ApiRegionsMergeHandler.merge(stableJson, prereleaseJson));
+    }
+
+    private JsonObject firstObjectRegion(final String json) {
+        try (final JsonReader reader = Json.createReader(new StringReader(json))) {
+            final JsonArray result = reader.readArray();
+            assertEquals(1, result.size());
+            final JsonValue value = result.get(0);
+            assertEquals(JsonValue.ValueType.OBJECT, value.getValueType());
+            final JsonObject region = value.asJsonObject();
+            assertNotNull(region);
+            return region;
+        }
+    }
+}

--- a/src/test/java/com/adobe/aem/analyser/ApiRegionsMergeHandlerTest.java
+++ b/src/test/java/com/adobe/aem/analyser/ApiRegionsMergeHandlerTest.java
@@ -49,18 +49,17 @@ public class ApiRegionsMergeHandlerTest {
         assertEquals("prerelease-kind", mergedRegion.getString("kind"));
     }
 
-    //?
     @Test
-    public void testMergeKeepsOnlyPrereleaseRegionSet() {
+    public void testMergeAppendsStableOnlyRegionsAfterPrereleaseRegions() {
         final String stableJson = "[{\"name\":\"global\",\"exports\":[\"stable.api\"]},{\"name\":\"internal\",\"exports\":[\"internal.api\"]}]";
         final String prereleaseJson = "[{\"name\":\"global\",\"exports\":[\"prerelease.api\"]}]";
 
-        String merge = ApiRegionsMergeHandler.merge(stableJson, prereleaseJson);
-        try (final JsonReader reader = Json.createReader(new StringReader(merge))) {
+        try (final JsonReader reader = Json.createReader(new StringReader(ApiRegionsMergeHandler.merge(stableJson, prereleaseJson)))) {
             final JsonArray regions = reader.readArray();
 
-            assertEquals(1, regions.size());
+            assertEquals(2, regions.size());
             assertEquals("global", regions.getJsonObject(0).getString("name"));
+            assertEquals("internal", regions.getJsonObject(1).getString("name"));
         }
     }
 

--- a/src/test/java/com/adobe/aem/analyser/ApiRegionsMergeHandlerTest.java
+++ b/src/test/java/com/adobe/aem/analyser/ApiRegionsMergeHandlerTest.java
@@ -21,51 +21,55 @@ import org.junit.Test;
 import java.io.StringReader;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 
 public class ApiRegionsMergeHandlerTest {
 
     @Test
-    public void testMergeUsesStableExportsWhenPrereleaseExportsMissing() {
-        final String stableJson = "[{\"name\":\"global\",\"exports\":[\"a.b\"]}]";
-        final String prereleaseJson = "[{\"name\":\"global\",\"imports\":[\"x.y\"]}]";
+    public void testMergeMergesExportsByPackageNameWithPrereleasePrecedence() {
+        final String stableJson = "[{\"name\":\"global\",\"exports\":[{\"name\":\"ch.qos.logback.classic\",\"deprecated\":{\"msg\":\"stable-msg\",\"since\":\"2022-01-27\",\"for-removal\":\"2025-08-31\"}},{\"name\":\"org.apache.abdera.ext.opensearch\",\"deprecated\":{\"msg\":\"legacy-stable\",\"since\":\"2019-04-08\",\"for-removal\":\"2025-08-31\"}}]}]";
+        final String prereleaseJson = "[{\"name\":\"global\",\"exports\":[{\"name\":\"ch.qos.logback.classic\",\"deprecated\":{\"msg\":\"prerelease-msg\",\"since\":\"2022-01-27\",\"for-removal\":\"2025-08-31\"}},{\"name\":\"com.example.new.api\",\"deprecated\":{\"msg\":\"new-prerelease\",\"since\":\"2026-01-01\",\"for-removal\":\"2028-01-01\"}}]}]";
 
         final JsonObject mergedRegion = firstObjectRegion(ApiRegionsMergeHandler.merge(stableJson, prereleaseJson));
+        final JsonArray exports = mergedRegion.getJsonArray("exports");
 
-        assertEquals("a.b", mergedRegion.getJsonArray("exports").getString(0));
-        assertEquals("x.y", mergedRegion.getJsonArray("imports").getString(0));
+        assertEquals(3, exports.size());
+        assertEquals("prerelease-msg", deprecatedMessageByExportName(exports, "ch.qos.logback.classic"));
+        assertEquals("legacy-stable", deprecatedMessageByExportName(exports, "org.apache.abdera.ext.opensearch"));
+        assertEquals("new-prerelease", deprecatedMessageByExportName(exports, "com.example.new.api"));
     }
 
     @Test
-    public void testMergeUsesStableExportsWhenPrereleaseExportsEmpty() {
-        final String stableJson = "[{\"name\":\"global\",\"exports\":[\"a.b\"]}]";
-        final String prereleaseJson = "[{\"name\":\"global\",\"exports\":[]}]";
+    public void testMergeKeepsPrereleaseRegionProperties() {
+        final String stableJson = "[{\"name\":\"global\",\"exports\":[\"stable.api\"],\"kind\":\"stable-kind\"}]";
+        final String prereleaseJson = "[{\"name\":\"global\",\"exports\":[\"prerelease.api\"],\"kind\":\"prerelease-kind\"}]";
 
         final JsonObject mergedRegion = firstObjectRegion(ApiRegionsMergeHandler.merge(stableJson, prereleaseJson));
 
-        assertEquals("a.b", mergedRegion.getJsonArray("exports").getString(0));
+        assertEquals("prerelease-kind", mergedRegion.getString("kind"));
     }
 
+    //?
     @Test
-    public void testMergeKeepsPrereleaseExportsWhenNonEmpty() {
-        final String stableJson = "[{\"name\":\"global\",\"exports\":[\"stable.api\"]}]";
+    public void testMergeKeepsOnlyPrereleaseRegionSet() {
+        final String stableJson = "[{\"name\":\"global\",\"exports\":[\"stable.api\"]},{\"name\":\"internal\",\"exports\":[\"internal.api\"]}]";
         final String prereleaseJson = "[{\"name\":\"global\",\"exports\":[\"prerelease.api\"]}]";
 
-        final JsonObject mergedRegion = firstObjectRegion(ApiRegionsMergeHandler.merge(stableJson, prereleaseJson));
+        String merge = ApiRegionsMergeHandler.merge(stableJson, prereleaseJson);
+        try (final JsonReader reader = Json.createReader(new StringReader(merge))) {
+            final JsonArray regions = reader.readArray();
 
-        assertEquals("prerelease.api", mergedRegion.getJsonArray("exports").getString(0));
+            assertEquals(1, regions.size());
+            assertEquals("global", regions.getJsonObject(0).getString("name"));
+        }
     }
 
     @Test
-    public void testMergeKeepsUnnamedRegionUnchanged() {
-        final String stableJson = "[{\"name\":\"global\",\"exports\":[\"stable.api\"]}]";
-        final String prereleaseJson = "[{\"exports\":[]}]";
+    public void testMergeReturnsPrereleaseWhenStableJsonContainsNonModelFields() {
+        final String stableJson = "[{\"name\":\"global\",\"imports\":[\"x.y\"],\"exports\":[\"stable.api\"]}]";
+        final String prereleaseJson = "[{\"name\":\"global\",\"exports\":[\"prerelease.api\"]}]";
 
-        final JsonObject mergedRegion = firstObjectRegion(ApiRegionsMergeHandler.merge(stableJson, prereleaseJson));
-
-        assertFalse(mergedRegion.containsKey("name"));
-        assertEquals(0, mergedRegion.getJsonArray("exports").size());
+        assertEquals(prereleaseJson, ApiRegionsMergeHandler.merge(stableJson, prereleaseJson));
     }
 
     @Test
@@ -83,6 +87,44 @@ public class ApiRegionsMergeHandlerTest {
         assertEquals(prereleaseJson, ApiRegionsMergeHandler.merge(stableJson, prereleaseJson));
     }
 
+    @Test
+    public void testMergeAddsStableExportsWhenPrereleaseRegionsHaveNoExports() {
+        final String stableJson = "[{\"name\":\"global\",\"exports\":[{\"name\":\"ch.qos.logback.classic\",\"deprecated\":{\"msg\":\"This internal logback API is not supported by AEM as a Cloud Service.\",\"since\":\"2022-01-27\",\"for-removal\":\"2025-08-31\"}}]},{\"name\":\"com.adobe.aem.deprecated\",\"exports\":[{\"name\":\"org.apache.abdera.ext.opensearch\",\"deprecated\":{\"msg\":\"Legacy AEM 6.x API.\",\"since\":\"2019-04-08\",\"for-removal\":\"2025-08-31\"}}]}]";
+        final String prereleaseJson = "[{\"name\":\"global\"},{\"name\":\"com.adobe.aem.deprecated\"}]";
+
+        try (final JsonReader reader = Json.createReader(new StringReader(ApiRegionsMergeHandler.merge(stableJson, prereleaseJson)))) {
+            final JsonArray regions = reader.readArray();
+            assertEquals(2, regions.size());
+
+            final JsonObject global = regionByName(regions, "global");
+            final JsonObject deprecated = regionByName(regions, "com.adobe.aem.deprecated");
+            assertNotNull(global);
+            assertNotNull(deprecated);
+
+            final JsonArray globalExports = global.getJsonArray("exports");
+            final JsonArray deprecatedExports = deprecated.getJsonArray("exports");
+            assertNotNull(globalExports);
+            assertNotNull(deprecatedExports);
+            assertEquals(1, globalExports.size());
+            assertEquals(1, deprecatedExports.size());
+            assertEquals("This internal logback API is not supported by AEM as a Cloud Service.", deprecatedMessageByExportName(globalExports, "ch.qos.logback.classic"));
+            assertEquals("Legacy AEM 6.x API.", deprecatedMessageByExportName(deprecatedExports, "org.apache.abdera.ext.opensearch"));
+        }
+    }
+
+    private String deprecatedMessageByExportName(final JsonArray exports, final String packageName) {
+        for (final JsonValue export : exports) {
+            if (export.getValueType() == JsonValue.ValueType.OBJECT) {
+                final JsonObject exportObject = export.asJsonObject();
+                if (packageName.equals(exportObject.getString("name", null))) {
+                    final JsonObject deprecated = exportObject.getJsonObject("deprecated");
+                    return deprecated != null ? deprecated.getString("msg", null) : null;
+                }
+            }
+        }
+        return null;
+    }
+
     private JsonObject firstObjectRegion(final String json) {
         try (final JsonReader reader = Json.createReader(new StringReader(json))) {
             final JsonArray result = reader.readArray();
@@ -93,5 +135,17 @@ public class ApiRegionsMergeHandlerTest {
             assertNotNull(region);
             return region;
         }
+    }
+
+    private JsonObject regionByName(final JsonArray regions, final String name) {
+        for (final JsonValue regionValue : regions) {
+            if (regionValue.getValueType() == JsonValue.ValueType.OBJECT) {
+                final JsonObject region = regionValue.asJsonObject();
+                if (name.equals(region.getString("name", null))) {
+                    return region;
+                }
+            }
+        }
+        return null;
     }
 }

--- a/src/test/java/com/adobe/aem/analyser/AssemblyBasedFeatureConflictResolverTest.java
+++ b/src/test/java/com/adobe/aem/analyser/AssemblyBasedFeatureConflictResolverTest.java
@@ -1,0 +1,174 @@
+/*
+  Copyright 2022 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.apache.sling.feature.Artifact;
+import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Extension;
+import org.apache.sling.feature.ExtensionState;
+import org.apache.sling.feature.ExtensionType;
+import org.apache.sling.feature.Feature;
+import org.junit.Test;
+
+public class AssemblyBasedFeatureConflictResolverTest {
+
+    private final AssemblyBasedFeatureConflictResolver resolver = new AssemblyBasedFeatureConflictResolver();
+
+    @Test
+    public void testResolveVersionConflictCopiesExtensionWhenOnlyInPrerelease() {
+        Feature stable = createStableFeature();
+        Feature prerelease = createPrereleaseFeature();
+
+        Extension prereleaseOnly = new Extension(ExtensionType.TEXT, Extension.EXTENSION_NAME_REPOINIT, ExtensionState.OPTIONAL);
+        prereleaseOnly.setText("prerelease-content");
+        prerelease.getExtensions().add(prereleaseOnly);
+
+        Feature merged = resolver.resolveVersionConflict(stable, prerelease, SdkProductVariation.AUTHOR);
+
+        Extension mergedExt = merged.getExtensions().getByName(Extension.EXTENSION_NAME_REPOINIT);
+        assertNotNull(mergedExt);
+        assertEquals(ExtensionType.TEXT, mergedExt.getType());
+        assertEquals("prerelease-content", mergedExt.getText());
+    }
+
+    @Test
+    public void testResolveVersionConflictReplacesTextExtensionWithPrerelease() {
+        Feature stable = createStableFeature();
+        Feature prerelease = createPrereleaseFeature();
+
+        Extension stableText = new Extension(ExtensionType.TEXT, Extension.EXTENSION_NAME_REPOINIT, ExtensionState.OPTIONAL);
+        stableText.setText("stable-text");
+        stable.getExtensions().add(stableText);
+
+        Extension prereleaseText = new Extension(ExtensionType.TEXT, Extension.EXTENSION_NAME_REPOINIT, ExtensionState.OPTIONAL);
+        prereleaseText.setText("prerelease-text");
+        prerelease.getExtensions().add(prereleaseText);
+
+        Feature merged = resolver.resolveVersionConflict(stable, prerelease, SdkProductVariation.AUTHOR);
+
+        Extension mergedText = merged.getExtensions().getByName(Extension.EXTENSION_NAME_REPOINIT);
+        assertNotNull(mergedText);
+        assertEquals("prerelease-text", mergedText.getText());
+    }
+
+    @Test
+    public void testResolveVersionConflictNotReplacesTextExtensionWithEmptyPrerelease() {
+        Feature stable = createStableFeature();
+        Feature prerelease = createPrereleaseFeature();
+
+        Extension stableText = new Extension(ExtensionType.TEXT, Extension.EXTENSION_NAME_REPOINIT, ExtensionState.OPTIONAL);
+        stableText.setText("stable-text");
+        stable.getExtensions().add(stableText);
+
+        Feature merged = resolver.resolveVersionConflict(stable, prerelease, SdkProductVariation.AUTHOR);
+
+        Extension mergedText = merged.getExtensions().getByName(Extension.EXTENSION_NAME_REPOINIT);
+        assertNotNull(mergedText);
+        assertEquals("stable-text", mergedText.getText());
+    }
+
+    @Test
+    public void testResolveVersionConflictMergesApiRegionsJsonHappyPath() {
+        Feature stable = createStableFeature();
+        Feature prerelease = createPrereleaseFeature();
+
+        Extension stableApiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+        stableApiRegions.setJSON("[{\"name\":\"global\",\"exports\":[\"stable.api\"]}]");
+        stable.getExtensions().add(stableApiRegions);
+
+        Extension prereleaseApiRegions = new Extension(ExtensionType.JSON, "api-regions", ExtensionState.OPTIONAL);
+        prereleaseApiRegions.setJSON("[{\"name\":\"global\",\"exports\":[\"prerelease.api\"]}]");
+        prerelease.getExtensions().add(prereleaseApiRegions);
+
+        Feature merged = resolver.resolveVersionConflict(stable, prerelease, SdkProductVariation.AUTHOR);
+
+        Extension mergedApiRegions = merged.getExtensions().getByName("api-regions");
+        assertNotNull(mergedApiRegions);
+        assertEquals("[{\"name\":\"global\",\"exports\":[\"stable.api\",\"prerelease.api\"]}]", mergedApiRegions.getJSON());
+    }
+
+
+    @Test
+    public void testResolveVersionConflictReplacesArtifactsExtensionWithPrerelease() {
+        Feature stable = createStableFeature();
+        Feature prerelease = createPrereleaseFeature();
+
+        Extension stableArtifacts = new Extension(ExtensionType.ARTIFACTS, "artifacts-ext", ExtensionState.OPTIONAL);
+        stableArtifacts.getArtifacts().add(new Artifact(ArtifactId.fromMvnId("g:stable.bundle:1.0.0")));
+        stableArtifacts.getArtifacts().add(new Artifact(ArtifactId.fromMvnId("g:shared.bundle:1.0.1")));
+        stable.getExtensions().add(stableArtifacts);
+
+        Extension prereleaseArtifacts = new Extension(ExtensionType.ARTIFACTS, "artifacts-ext", ExtensionState.OPTIONAL);
+        prereleaseArtifacts.getArtifacts().add(new Artifact(ArtifactId.fromMvnId("g:prerelease.bundle:2.0.0")));
+        prereleaseArtifacts.getArtifacts().add(new Artifact(ArtifactId.fromMvnId("g:new.bundle:3.0.0")));
+        prereleaseArtifacts.getArtifacts().add(new Artifact(ArtifactId.fromMvnId("g:shared.bundle:1.0.0")));
+        prerelease.getExtensions().add(prereleaseArtifacts);
+
+        Feature merged = resolver.resolveVersionConflict(stable, prerelease, SdkProductVariation.AUTHOR);
+
+        Extension mergedArtifacts = merged.getExtensions().getByName("artifacts-ext");
+        assertNotNull(mergedArtifacts);
+        assertEquals(4, mergedArtifacts.getArtifacts().size());
+        assertEquals("1.0.0", findArtifactVersion(mergedArtifacts, "stable.bundle"));
+        assertEquals("2.0.0", findArtifactVersion(mergedArtifacts, "prerelease.bundle"));
+        assertEquals("3.0.0", findArtifactVersion(mergedArtifacts, "new.bundle"));
+        assertEquals("1.0.0", findArtifactVersion(mergedArtifacts, "shared.bundle"));
+    }
+
+    @Test
+    public void testResolveVersionConflictMergesVariablesAndFrameworkProperties() {
+        Feature stable = createStableFeature();
+        stable.getVariables().put("stable.only", "stable-value");
+        stable.getVariables().put("common.var", "stable-common");
+        stable.getFrameworkProperties().put("stable.fw.only", "stable-fw-value");
+        stable.getFrameworkProperties().put("common.fw", "stable-fw-common");
+
+        Feature prerelease = createPrereleaseFeature();
+        prerelease.getVariables().put("prerelease.only", "prerelease-value");
+        prerelease.getVariables().put("common.var", "prerelease-common");
+        prerelease.getFrameworkProperties().put("prerelease.fw.only", "prerelease-fw-value");
+        prerelease.getFrameworkProperties().put("common.fw", "prerelease-fw-common");
+
+        Feature merged = resolver.resolveVersionConflict(stable, prerelease, SdkProductVariation.AUTHOR);
+
+        assertEquals(3, merged.getVariables().size());
+        assertEquals("stable-value", merged.getVariables().get("stable.only"));
+        assertEquals("prerelease-value", merged.getVariables().get("prerelease.only"));
+        assertEquals("prerelease-common", merged.getVariables().get("common.var"));
+
+        assertEquals(3, merged.getFrameworkProperties().size());
+        assertEquals("stable-fw-value", merged.getFrameworkProperties().get("stable.fw.only"));
+        assertEquals("prerelease-fw-value", merged.getFrameworkProperties().get("prerelease.fw.only"));
+        assertEquals("prerelease-fw-common", merged.getFrameworkProperties().get("common.fw"));
+    }
+
+    private static Feature createStableFeature() {
+        return new Feature(ArtifactId.fromMvnId(
+                "com.adobe.aem:aem-sdk-api:slingosgifeature:aem-author-sdk:1.0.0"));
+    }
+
+    private static Feature createPrereleaseFeature() {
+        return new Feature(ArtifactId.fromMvnId(
+                "com.adobe.aem:aem-prerelease-sdk-api:slingosgifeature:aem-author-sdk:1.0.0"));
+    }
+
+    private static String findArtifactVersion(final Extension artifactsExtension, final String artifactId) {
+        return artifactsExtension.getArtifacts().stream()
+                .filter(artifact -> artifactId.equals(artifact.getId().getArtifactId()))
+                .findFirst()
+                .map(artifact -> artifact.getId().getVersion())
+                .orElse(null);
+    }
+}


### PR DESCRIPTION
In this PR, I added support for merging prerelease SDKs and add-ons with their regular counterparts.

## Description

For now, this functionality is available only through AemAggregator when the following fields are provided:

prereleaseSdkId
prereleaseAddOnIds

If these fields are left empty, the behavior remains unchanged. When they are set, the features from the prerelease SDK and/or add-ons are merged with the corresponding regular SDK and add-ons.

## Related Issue
[#362](https://github.com/adobe/aemanalyser-maven-plugin/issues/362)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
