### PR TITLE
Add optional JSON report file for analyser results

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,36 @@ The plugin can be configured with the following configuration properties:
 * **classifier**  : If this property is set the content package to analyze is retrieved from the attached project artifact with the given classifier. The value for this property can also be specified via the command line by setting `aem.analyser.classifier`.
 * **contentPackageFiles**: Analyzes the given list of content package files. If this is configured, only these files are validated, and not the main project artifact or dependencies. The files must be located inside the Maven project directory (e.g. src or target folder).
 * **repoInitValidation**: If this is set to `true`, the plugin will execute the repoinit statements in an in-memory JCR repository. In case of failures such as missing CreatePath statements, the build will fail.
+* **reportFile**: If set, the analyser result (all errors and warnings) is written to this file as JSON in addition to being logged. This provides a stable, machine readable report that third party tools can consume instead of scraping the build log. Deprecated API findings are additionally decomposed into a structured `deprecation` object. The value can also be specified from the command line via `aem.analyser.report.file`. See [Report File](#report-file) for the document format.
+
+## Report File
+
+When the **reportFile** property is set, the plugin writes the analyser result as a JSON document. Enabling the report never changes the outcome of the build; if the report cannot be written a warning is logged and the build continues.
+
+The document has the following shape:
+
+    {
+      "schemaVersion": "1.0",
+      "generatedAt": "2026-07-28T10:15:30Z",
+      "errors": 1,
+      "warnings": 2,
+      "findings": [
+        {
+          "level": "error",
+          "tier": "author",
+          "message": "Usage of deprecated package found : com.foo : Use com.bar instead Deprecated since 2023.1 For removal : 2025-01-01",
+          "deprecation": {
+            "kind": "package",
+            "packages": [ "com.foo" ],
+            "hint": "Use com.bar instead",
+            "since": "2023.1",
+            "forRemoval": "2025-01-01"
+          }
+        }
+      ]
+    }
+
+The `message` field is always the verbatim analyser message, so consumers are never forced to rely on the parsed fields. The `deprecation` object is a best effort structured view emitted only for findings from the `region-deprecated-api` analyser task. For findings that stem from a deprecated *library* the object also carries a `library` name and lists every affected package; when the finding could be attributed to a content package, an `origin` field is included. The `hint` typically describes the suggested replacement (the "fix").
 
 ## Advanced Configurations
 

--- a/src/main/java/com/adobe/aem/analyser/mojos/AbstractAemMojo.java
+++ b/src/main/java/com/adobe/aem/analyser/mojos/AbstractAemMojo.java
@@ -15,6 +15,9 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -38,6 +41,7 @@ import org.eclipse.aether.resolution.ArtifactResult;
 
 import com.adobe.aem.analyser.result.AemAnalyserAnnotation;
 import com.adobe.aem.analyser.result.AemAnalyserResult;
+import com.adobe.aem.analyser.result.AemAnalyserResultJsonWriter;
 
 /**
  * Abstract base class for all mojos
@@ -73,6 +77,17 @@ public abstract class AbstractAemMojo extends AbstractMojo {
      */
     @Parameter(defaultValue = "false", property = "aem.analyser.strict")
     protected boolean strictValidation;
+
+    /**
+     * If set, the analyser result (all errors and warnings, including the
+     * deprecated API findings in a structured form) is written to this file as
+     * JSON. This provides a stable, machine readable report that third party
+     * tools can consume instead of scraping the build log. See
+     * {@link AemAnalyserResultJsonWriter} for the document format.
+     * @since 1.6.25
+     */
+    @Parameter(property = "aem.analyser.report.file")
+    protected File reportFile;
 
     /**
      * Find the artifact in the collection
@@ -168,6 +183,31 @@ public abstract class AbstractAemMojo extends AbstractMojo {
         }
         for(final AemAnalyserAnnotation ann : result.getErrors()) {
             getLog().error(ann.toString());
+        }
+    }
+
+    /**
+     * If a {@link #reportFile} is configured, write the analyser result to it as
+     * JSON. Failures to write the report are logged as a warning and never fail
+     * the build, so enabling the report cannot change the outcome of an analyse
+     * run.
+     * @param result the analyser result to serialise
+     */
+    protected void writeReport(final AemAnalyserResult result) {
+        if (this.reportFile == null) {
+            return;
+        }
+        try {
+            final File parent = this.reportFile.getAbsoluteFile().getParentFile();
+            if (parent != null) {
+                Files.createDirectories(parent.toPath());
+            }
+            try (final Writer writer = Files.newBufferedWriter(this.reportFile.toPath(), StandardCharsets.UTF_8)) {
+                AemAnalyserResultJsonWriter.write(result, writer);
+            }
+            getLog().info("Wrote AEM analyser report to " + this.reportFile.getAbsolutePath());
+        } catch (final IOException e) {
+            getLog().warn("Unable to write AEM analyser report to " + this.reportFile.getAbsolutePath(), e);
         }
     }
 }

--- a/src/main/java/com/adobe/aem/analyser/mojos/AbstractAnalyseMojo.java
+++ b/src/main/java/com/adobe/aem/analyser/mojos/AbstractAnalyseMojo.java
@@ -139,6 +139,8 @@ public abstract class AbstractAnalyseMojo extends AbstractAemMojo {
 
         this.printResult(result);
 
+        this.writeReport(result);
+
         if (hasErrors) {
             if ( failOnAnalyserErrors ) {
                 throw new MojoFailureException(

--- a/src/main/java/com/adobe/aem/analyser/result/AemAnalyserResultJsonWriter.java
+++ b/src/main/java/com/adobe/aem/analyser/result/AemAnalyserResultJsonWriter.java
@@ -1,0 +1,296 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser.result;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonWriter;
+import jakarta.json.JsonWriterFactory;
+import jakarta.json.stream.JsonGenerator;
+
+/**
+ * Serialises an {@link AemAnalyserResult} into a stable, machine readable JSON
+ * document. The intent is to let third party tools consume the analyser output
+ * &ndash; in particular the deprecated API findings &ndash; from a well defined
+ * file instead of scraping the Maven build log.
+ *
+ * <p>The document has the following shape:</p>
+ * <pre>
+ * {
+ *   "schemaVersion": "1.0",
+ *   "generatedAt": "2026-07-28T10:15:30Z",
+ *   "errors": 1,
+ *   "warnings": 2,
+ *   "findings": [
+ *     {
+ *       "level": "error",
+ *       "tier": "author",
+ *       "message": "Usage of deprecated package found : com.foo : Use com.bar instead Deprecated since 2023.1 For removal : 2025-01-01",
+ *       "deprecation": {
+ *         "kind": "package",
+ *         "packages": [ "com.foo" ],
+ *         "hint": "Use com.bar instead",
+ *         "since": "2023.1",
+ *         "forRemoval": "2025-01-01"
+ *       }
+ *     }
+ *   ]
+ * }
+ * </pre>
+ *
+ * <p>The {@code message} field is always the verbatim analyser message so that
+ * consumers are never forced to rely on the parsed {@code deprecation} object.
+ * The {@code deprecation} object is a best effort structured view that is only
+ * emitted when the message matches the {@code region-deprecated-api} format.</p>
+ */
+public class AemAnalyserResultJsonWriter {
+
+    /** Schema version of the emitted document. Bump on incompatible changes. */
+    public static final String SCHEMA_VERSION = "1.0";
+
+    private static final String LEVEL_ERROR = "error";
+
+    private static final String LEVEL_WARNING = "warning";
+
+    /**
+     * Matches the section header lines that {@code AemAnalyser} inserts into the
+     * flat result lists, e.g. "The analyser found the following errors for author : ".
+     * Group 1 is the finding type, group 2 the tier.
+     */
+    private static final Pattern HEADER =
+        Pattern.compile("^The analyser found the following (errors|warnings) for (.+) : $");
+
+    private static final String PKG_PREFIX = "Usage of deprecated package found : ";
+
+    private static final String LIB_PREFIX = "Usage of deprecated library found : ";
+
+    private static final String LIB_PACKAGES_SEP = ", package(s) : ";
+
+    private static final String MARK_SINCE = " Deprecated since ";
+
+    private static final String MARK_FOR_REMOVAL = " For removal : ";
+
+    private static final String MARK_SCHEDULED = " The package is scheduled to be removed in less than ";
+
+    private static final String MARK_SCHEDULED_BY = " days by ";
+
+    private AemAnalyserResultJsonWriter() {
+        // static helper
+    }
+
+    /**
+     * Write the given result as JSON to the provided writer.
+     *
+     * @param result the analyser result, must not be {@code null}
+     * @param out the target writer, must not be {@code null}
+     * @throws IOException if writing fails
+     */
+    public static void write(final AemAnalyserResult result, final Writer out) throws IOException {
+        final JsonObjectBuilder root = Json.createObjectBuilder();
+        root.add("schemaVersion", SCHEMA_VERSION);
+        root.add("generatedAt", Instant.now().toString());
+        root.add("errors", result.getErrors().size());
+        root.add("warnings", result.getWarnings().size());
+
+        final JsonArrayBuilder findings = Json.createArrayBuilder();
+        appendFindings(findings, result.getErrors(), LEVEL_ERROR);
+        appendFindings(findings, result.getWarnings(), LEVEL_WARNING);
+        root.add("findings", findings);
+
+        final Map<String, Object> config =
+            Collections.singletonMap(JsonGenerator.PRETTY_PRINTING, Boolean.TRUE);
+        final JsonWriterFactory factory = Json.createWriterFactory(config);
+        try (final JsonWriter jsonWriter = factory.createWriter(out)) {
+            jsonWriter.writeObject(root.build());
+        }
+    }
+
+    private static void appendFindings(final JsonArrayBuilder findings,
+            final List<AemAnalyserAnnotation> annotations, final String level) {
+        String tier = null;
+        for (final AemAnalyserAnnotation ann : annotations) {
+            final String message = ann.getMessage();
+            final Matcher headerMatcher = HEADER.matcher(message);
+            if (headerMatcher.matches()) {
+                // Section header - remember the tier, do not emit it as a finding.
+                tier = headerMatcher.group(2);
+                continue;
+            }
+
+            final JsonObjectBuilder finding = Json.createObjectBuilder();
+            finding.add("level", level);
+            if (tier != null) {
+                finding.add("tier", tier);
+            }
+            finding.add("message", message);
+
+            final Map<String, Object> deprecation = parseDeprecation(message);
+            if (deprecation != null) {
+                finding.add("deprecation", toJson(deprecation));
+            }
+            findings.add(finding);
+        }
+    }
+
+    /**
+     * Best effort parse of a {@code region-deprecated-api} message into a
+     * structured map. Returns {@code null} if the message is not a deprecation
+     * finding.
+     */
+    static Map<String, Object> parseDeprecation(final String rawMessage) {
+        String message = rawMessage;
+        // The message may carry a trailing " (origin...)" content package origin
+        // suffix appended by AemAnalyser. Keep it out of the parsed fields.
+        String origin = null;
+        if (message.endsWith(")")) {
+            final int open = message.lastIndexOf(" (");
+            if (open > 0) {
+                origin = message.substring(open + 2, message.length() - 1);
+                message = message.substring(0, open);
+            }
+        }
+
+        final Map<String, Object> result = new HashMap<>();
+        final List<String> packages = new ArrayList<>();
+        final String remainder;
+
+        if (message.startsWith(PKG_PREFIX)) {
+            result.put("kind", "package");
+            final String body = message.substring(PKG_PREFIX.length());
+            final int sep = body.indexOf(" : ");
+            if (sep < 0) {
+                return null;
+            }
+            packages.add(body.substring(0, sep).trim());
+            remainder = body.substring(sep + 3);
+        } else if (message.startsWith(LIB_PREFIX)) {
+            result.put("kind", "library");
+            final String body = message.substring(LIB_PREFIX.length());
+            final int libSep = body.indexOf(LIB_PACKAGES_SEP);
+            if (libSep < 0) {
+                return null;
+            }
+            result.put("library", body.substring(0, libSep).trim());
+            final String afterLib = body.substring(libSep + LIB_PACKAGES_SEP.length());
+            final int sep = afterLib.indexOf(" : ");
+            if (sep < 0) {
+                return null;
+            }
+            for (final String pkg : afterLib.substring(0, sep).split(",")) {
+                final String trimmed = pkg.trim();
+                if (!trimmed.isEmpty()) {
+                    packages.add(trimmed);
+                }
+            }
+            remainder = afterLib.substring(sep + 3);
+        } else {
+            return null;
+        }
+
+        result.put("packages", packages);
+        parseHintSinceRemoval(remainder, result);
+        if (origin != null) {
+            result.put("origin", origin);
+        }
+        return result;
+    }
+
+    private static void parseHintSinceRemoval(final String remainder, final Map<String, Object> result) {
+        // Find the earliest trailer marker; everything before it is the hint.
+        final int sinceIdx = remainder.indexOf(MARK_SINCE);
+        final int removalIdx = remainder.indexOf(MARK_FOR_REMOVAL);
+        final int scheduledIdx = remainder.indexOf(MARK_SCHEDULED);
+
+        final int hintEnd = firstNonNegative(sinceIdx, removalIdx, scheduledIdx);
+        final String hint = (hintEnd < 0 ? remainder : remainder.substring(0, hintEnd)).trim();
+        if (!hint.isEmpty()) {
+            result.put("hint", hint);
+        }
+
+        if (sinceIdx >= 0) {
+            final int sinceStart = sinceIdx + MARK_SINCE.length();
+            final int sinceEnd = firstNonNegativeFrom(sinceStart, removalIdx, scheduledIdx);
+            final String since = (sinceEnd < 0 ? remainder.substring(sinceStart)
+                : remainder.substring(sinceStart, sinceEnd)).trim();
+            if (!since.isEmpty()) {
+                result.put("since", since);
+            }
+        }
+
+        if (removalIdx >= 0) {
+            final String forRemoval = remainder.substring(removalIdx + MARK_FOR_REMOVAL.length()).trim();
+            if (!forRemoval.isEmpty()) {
+                result.put("forRemoval", forRemoval);
+            }
+        } else if (scheduledIdx >= 0) {
+            final int byIdx = remainder.indexOf(MARK_SCHEDULED_BY, scheduledIdx);
+            if (byIdx >= 0) {
+                final String forRemoval = remainder.substring(byIdx + MARK_SCHEDULED_BY.length()).trim();
+                if (!forRemoval.isEmpty()) {
+                    result.put("forRemoval", forRemoval);
+                }
+            }
+        }
+    }
+
+    /** @return the smallest non-negative value, or -1 if all are negative. */
+    private static int firstNonNegative(final int... values) {
+        int min = -1;
+        for (final int v : values) {
+            if (v >= 0 && (min < 0 || v < min)) {
+                min = v;
+            }
+        }
+        return min;
+    }
+
+    /** As {@link #firstNonNegative} but only considers values greater than {@code from}. */
+    private static int firstNonNegativeFrom(final int from, final int... values) {
+        int min = -1;
+        for (final int v : values) {
+            if (v >= from && (min < 0 || v < min)) {
+                min = v;
+            }
+        }
+        return min;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static JsonObjectBuilder toJson(final Map<String, Object> map) {
+        final JsonObjectBuilder builder = Json.createObjectBuilder();
+        for (final Map.Entry<String, Object> entry : map.entrySet()) {
+            final Object value = entry.getValue();
+            if (value instanceof List) {
+                final JsonArrayBuilder array = Json.createArrayBuilder();
+                for (final String item : (List<String>) value) {
+                    array.add(item);
+                }
+                builder.add(entry.getKey(), array);
+            } else {
+                builder.add(entry.getKey(), value.toString());
+            }
+        }
+        return builder;
+    }
+}

--- a/src/test/java/com/adobe/aem/analyser/result/AemAnalyserResultJsonWriterTest.java
+++ b/src/test/java/com/adobe/aem/analyser/result/AemAnalyserResultJsonWriterTest.java
@@ -1,0 +1,162 @@
+/*
+  Copyright 2026 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+package com.adobe.aem.analyser.result;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import jakarta.json.Json;
+import jakarta.json.JsonArray;
+import jakarta.json.JsonObject;
+import jakarta.json.JsonReader;
+
+public class AemAnalyserResultJsonWriterTest {
+
+    private JsonObject write(final AemAnalyserResult result) throws Exception {
+        final StringWriter sw = new StringWriter();
+        AemAnalyserResultJsonWriter.write(result, sw);
+        try (final JsonReader reader = Json.createReader(new StringReader(sw.toString()))) {
+            return reader.readObject();
+        }
+    }
+
+    @Test
+    public void testEmptyResult() throws Exception {
+        final JsonObject json = write(new AemAnalyserResult());
+        assertEquals(AemAnalyserResultJsonWriter.SCHEMA_VERSION, json.getString("schemaVersion"));
+        assertEquals(0, json.getInt("errors"));
+        assertEquals(0, json.getInt("warnings"));
+        assertTrue(json.getJsonArray("findings").isEmpty());
+        assertTrue(json.containsKey("generatedAt"));
+    }
+
+    @Test
+    public void testCountsAndLevels() throws Exception {
+        final AemAnalyserResult result = new AemAnalyserResult();
+        result.getErrors().add(new AemAnalyserAnnotation("some error"));
+        result.getWarnings().add(new AemAnalyserAnnotation("some warning"));
+        result.getWarnings().add(new AemAnalyserAnnotation("another warning"));
+
+        final JsonObject json = write(result);
+        assertEquals(1, json.getInt("errors"));
+        assertEquals(2, json.getInt("warnings"));
+
+        final JsonArray findings = json.getJsonArray("findings");
+        assertEquals(3, findings.size());
+        assertEquals("error", findings.getJsonObject(0).getString("level"));
+        assertEquals("some error", findings.getJsonObject(0).getString("message"));
+        assertEquals("warning", findings.getJsonObject(1).getString("level"));
+        // plain messages carry no structured deprecation object
+        assertFalse(findings.getJsonObject(0).containsKey("deprecation"));
+    }
+
+    @Test
+    public void testHeaderBecomesTierAndIsNotAFinding() throws Exception {
+        final AemAnalyserResult result = new AemAnalyserResult();
+        result.getErrors().add(new AemAnalyserAnnotation("The analyser found the following errors for author : "));
+        result.getErrors().add(new AemAnalyserAnnotation("real finding"));
+
+        final JsonObject json = write(result);
+        final JsonArray findings = json.getJsonArray("findings");
+        assertEquals(1, findings.size());
+        assertEquals("author", findings.getJsonObject(0).getString("tier"));
+        assertEquals("real finding", findings.getJsonObject(0).getString("message"));
+    }
+
+    @Test
+    public void testDeprecatedPackageParsing() {
+        final Map<String, Object> d = AemAnalyserResultJsonWriter.parseDeprecation(
+            "Usage of deprecated package found : com.foo.bar : Use com.foo.baz instead"
+            + " Deprecated since 2023.1 For removal : 2025-01-01");
+
+        assertEquals("package", d.get("kind"));
+        assertEquals(List.of("com.foo.bar"), d.get("packages"));
+        assertEquals("Use com.foo.baz instead", d.get("hint"));
+        assertEquals("2023.1", d.get("since"));
+        assertEquals("2025-01-01", d.get("forRemoval"));
+    }
+
+    @Test
+    public void testDeprecatedPackageWithoutSinceOrRemoval() {
+        final Map<String, Object> d = AemAnalyserResultJsonWriter.parseDeprecation(
+            "Usage of deprecated package found : com.foo.bar : Use something else");
+
+        assertEquals("package", d.get("kind"));
+        assertEquals(List.of("com.foo.bar"), d.get("packages"));
+        assertEquals("Use something else", d.get("hint"));
+        assertNull(d.get("since"));
+        assertNull(d.get("forRemoval"));
+    }
+
+    @Test
+    public void testDeprecatedPackageScheduledForRemoval() {
+        final Map<String, Object> d = AemAnalyserResultJsonWriter.parseDeprecation(
+            "Usage of deprecated package found : com.foo.bar : Use com.foo.baz instead"
+            + " Deprecated since 2023.1 The package is scheduled to be removed in less than 90 days by 2025-01-01");
+
+        assertEquals("Use com.foo.baz instead", d.get("hint"));
+        assertEquals("2023.1", d.get("since"));
+        assertEquals("2025-01-01", d.get("forRemoval"));
+    }
+
+    @Test
+    public void testDeprecatedLibraryParsing() {
+        final Map<String, Object> d = AemAnalyserResultJsonWriter.parseDeprecation(
+            "Usage of deprecated library found : mylib, package(s) : com.foo, com.bar : Use newlib"
+            + " Deprecated since 2022 For removal : 2024-06-30");
+
+        assertEquals("library", d.get("kind"));
+        assertEquals("mylib", d.get("library"));
+        assertEquals(List.of("com.foo", "com.bar"), d.get("packages"));
+        assertEquals("Use newlib", d.get("hint"));
+        assertEquals("2022", d.get("since"));
+        assertEquals("2024-06-30", d.get("forRemoval"));
+    }
+
+    @Test
+    public void testDeprecationWithOriginSuffix() {
+        final Map<String, Object> d = AemAnalyserResultJsonWriter.parseDeprecation(
+            "Usage of deprecated package found : com.foo.bar : Use com.foo.baz instead"
+            + " For removal : 2025-01-01 (mvn:com.example:my-content:1.0.0)");
+
+        assertEquals("2025-01-01", d.get("forRemoval"));
+        assertEquals("mvn:com.example:my-content:1.0.0", d.get("origin"));
+    }
+
+    @Test
+    public void testNonDeprecationMessageIsNotParsed() {
+        assertNull(AemAnalyserResultJsonWriter.parseDeprecation("Some unrelated analyser error"));
+    }
+
+    @Test
+    public void testDeprecationEmbeddedInJson() throws Exception {
+        final AemAnalyserResult result = new AemAnalyserResult();
+        result.getWarnings().add(new AemAnalyserAnnotation(
+            "Usage of deprecated package found : com.foo.bar : Use com.foo.baz instead For removal : 2025-01-01"));
+
+        final JsonObject json = write(result);
+        final JsonObject finding = json.getJsonArray("findings").getJsonObject(0);
+        final JsonObject deprecation = finding.getJsonObject("deprecation");
+        assertEquals("package", deprecation.getString("kind"));
+        assertEquals("com.foo.bar", deprecation.getJsonArray("packages").getString(0));
+        assertEquals("2025-01-01", deprecation.getString("forRemoval"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `reportFile` mojo parameter that writes the AEM analyser result (errors and warnings) to a JSON file, giving external tooling a stable machine-readable report instead of scraping the build log.
- Deprecated-API findings are additionally decomposed into a structured `deprecation` object (kind, packages, hint, since, forRemoval, library/origin where applicable).
- Writing the report never affects build outcome; failures to write are logged as warnings only.
- Documents the new parameter and JSON schema in the README.

## Test plan
- [ ] `AemAnalyserResultJsonWriterTest` covers the JSON writer output
- [ ] `mvn test` passes locally