### PR TITLE
Refresh system bundle scanner cache key after aggregation

### DIFF
--- a/src/main/java/com/adobe/aem/analyser/AemAggregator.java
+++ b/src/main/java/com/adobe/aem/analyser/AemAggregator.java
@@ -48,6 +48,7 @@ import org.apache.sling.feature.extension.apiregions.api.artifacts.VersionRule;
 import org.apache.sling.feature.extension.apiregions.api.config.ConfigurationApi;
 import org.apache.sling.feature.io.json.FeatureJSONReader;
 import org.apache.sling.feature.io.json.FeatureJSONWriter;
+import org.apache.sling.feature.scanner.impl.SystemBundleDescriptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,6 +57,8 @@ import com.adobe.aem.project.ServiceType;
 import jakarta.json.Json;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonObjectBuilder;
+import jakarta.json.JsonString;
+import jakarta.json.JsonValue;
 
 /**
  * Create all the aggregates
@@ -508,6 +511,13 @@ public class AemAggregator {
 
             postProcessProductFeature(feature);
 
+            // The aggregate inherits the pre-computed system bundle scanner cache key from the SDK feature,
+            // but its framework properties are the union of all merged features. Add-ons (e.g. forms) may
+            // contribute extra framework properties, which makes the inherited cache key stale and forces a
+            // framework scan at analysis time. Recompute the cache key against the aggregate's framework
+            // properties so the analyser's scanner cache is hit instead.
+            refreshSystemBundleCacheKey(feature);
+
             final File featureFile = new File(this.getFeatureOutputDirectory(), aggregate.getKey().concat(".json"));
             try ( final Writer writer = new FileWriter(featureFile)) {
                 FeatureJSONWriter.write(writer, feature);
@@ -589,5 +599,78 @@ public class AemAggregator {
                 }
             }
         }
+    }
+
+    /** The analyser-metadata extension name. */
+    private static final String ANALYSER_METADATA_EXTENSION = "analyser-metadata";
+
+    /** The key under which the system bundle metadata is stored in the analyser-metadata extension. */
+    private static final String SYSTEM_BUNDLE_KEY = "extra-metadata:system.bundle:0";
+
+    /** The artifact id field of a system bundle metadata entry. */
+    private static final String ARTIFACT_ID_KEY = "artifactId";
+
+    /** The scanner cache key field of a system bundle metadata entry. */
+    private static final String SCANNER_CACHE_KEY = "scannerCacheKey";
+
+    /**
+     * Recompute the system bundle scanner cache key of the aggregated feature's analyser-metadata so that it
+     * matches the feature's framework properties.
+     *
+     * <p>The scanner cache key is the only part of the system bundle metadata that is derived from the
+     * framework properties (the manifest capabilities/exports describe the framework artifact itself). When
+     * features are aggregated the resulting framework properties are the union of all merged features, so a
+     * cache key that was pre-computed for one of the inputs (typically the SDK feature) no longer matches the
+     * aggregate. If left stale, the scanner cache lookup misses at analysis time and a framework scan is
+     * triggered - which is expensive and, in setups where framework scanning is disabled, fails the build.</p>
+     *
+     * @param feature The aggregated feature
+     */
+    final void refreshSystemBundleCacheKey(final Feature feature) {
+        final Extension ext = feature.getExtensions().getByName(ANALYSER_METADATA_EXTENSION);
+        if ( ext == null || ext.getType() != ExtensionType.JSON ) {
+            return;
+        }
+
+        final JsonObject metadata = ext.getJSONStructure().asJsonObject();
+        final JsonValue systemBundleValue = metadata.get(SYSTEM_BUNDLE_KEY);
+        if ( systemBundleValue == null || systemBundleValue.getValueType() != JsonValue.ValueType.OBJECT ) {
+            return;
+        }
+
+        final JsonObject systemBundle = systemBundleValue.asJsonObject();
+        final JsonValue artifactIdValue = systemBundle.get(ARTIFACT_ID_KEY);
+        if ( artifactIdValue == null || artifactIdValue.getValueType() != JsonValue.ValueType.STRING ) {
+            // no framework artifact id recorded - nothing we can key on
+            return;
+        }
+
+        final ArtifactId frameworkId = ArtifactId.fromMvnId(((JsonString) artifactIdValue).getString());
+        final String cacheKey = SystemBundleDescriptor.createCacheKey(frameworkId, feature.getFrameworkProperties());
+
+        final JsonValue existingKey = systemBundle.get(SCANNER_CACHE_KEY);
+        if ( existingKey != null && existingKey.getValueType() == JsonValue.ValueType.STRING
+                && cacheKey.equals(((JsonString) existingKey).getString()) ) {
+            // already matches the aggregate's framework properties, nothing to do
+            return;
+        }
+
+        logger.debug("Refreshing stale system bundle scanner cache key for feature {}", feature.getId().toMvnId());
+
+        // rebuild the system bundle entry with the refreshed cache key, then rebuild the whole extension
+        final JsonObject newSystemBundle = Json.createObjectBuilder(systemBundle)
+                .add(SCANNER_CACHE_KEY, cacheKey)
+                .build();
+
+        final JsonObjectBuilder newMetadataBuilder = Json.createObjectBuilder();
+        for (final String key : metadata.keySet()) {
+            if ( SYSTEM_BUNDLE_KEY.equals(key) ) {
+                newMetadataBuilder.add(key, newSystemBundle);
+            } else {
+                newMetadataBuilder.add(key, metadata.get(key));
+            }
+        }
+
+        ext.setJSONStructure(newMetadataBuilder.build());
     }
 }

--- a/src/test/java/com/adobe/aem/analyser/AemAggregatorTest.java
+++ b/src/test/java/com/adobe/aem/analyser/AemAggregatorTest.java
@@ -12,6 +12,7 @@
 package com.adobe.aem.analyser;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -19,6 +20,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.StringReader;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,14 +31,21 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.sling.feature.ArtifactId;
+import org.apache.sling.feature.Extension;
+import org.apache.sling.feature.ExtensionState;
+import org.apache.sling.feature.ExtensionType;
 import org.apache.sling.feature.Feature;
 import org.apache.sling.feature.builder.FeatureProvider;
 import org.apache.sling.feature.extension.apiregions.api.artifacts.ArtifactRules;
 import org.apache.sling.feature.extension.apiregions.api.artifacts.Mode;
 import org.apache.sling.feature.extension.apiregions.api.artifacts.VersionRule;
+import org.apache.sling.feature.scanner.impl.SystemBundleDescriptor;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+
+import jakarta.json.Json;
+import jakarta.json.JsonObject;
 
 public class AemAggregatorTest {
     public @Rule TemporaryFolder tempDir = new TemporaryFolder();
@@ -301,5 +310,114 @@ public class AemAggregatorTest {
         assertEquals(ArtifactId.parse("g:b:jar:c:1"), newRules.getArtifactVersionRules().get(1).getArtifactId());
         assertEquals(ArtifactId.parse("g:c:zip:cp2fm-converted:1"), newRules.getArtifactVersionRules().get(2).getArtifactId());
         assertNull(newRules.getArtifactVersionRules().get(3).getArtifactId());
+    }
+
+    private static final String ANALYSER_METADATA = "analyser-metadata";
+
+    private static final String SYSTEM_BUNDLE_KEY = "extra-metadata:system.bundle:0";
+
+    private static final ArtifactId FRAMEWORK_ID =
+            ArtifactId.parse("org.apache.felix:org.apache.felix.framework:7.0.5");
+
+    private static final String SYSTEM_BUNDLE_MANIFEST =
+            "{\"Provide-Capability\":\"osgi.ee; osgi.ee=JavaSE; version:List<Version>=\\\"1.8.0,17.0.0\\\"\","
+                    + "\"Export-Package\":\"org.osgi.framework;version=1.10.0\"}";
+
+    /**
+     * Build a feature that carries an analyser-metadata system bundle entry with the given scanner cache key
+     * and the given framework properties (passed as alternating key/value pairs).
+     */
+    private Feature featureWithSystemBundle(final String scannerCacheKey, final String... frameworkProps) {
+        final Feature feature = new Feature(ArtifactId.parse("g:aggregated:slingosgifeature:aggregated-publish:1"));
+
+        for (int i = 0; i < frameworkProps.length; i += 2) {
+            feature.getFrameworkProperties().put(frameworkProps[i], frameworkProps[i + 1]);
+        }
+
+        final String metadata = "{\"" + SYSTEM_BUNDLE_KEY + "\":{"
+                + "\"manifest\":" + SYSTEM_BUNDLE_MANIFEST + ","
+                + "\"artifactId\":\"" + FRAMEWORK_ID.toMvnId() + "\","
+                + "\"scannerCacheKey\":\"" + scannerCacheKey + "\""
+                + "}}";
+
+        final Extension ext = new Extension(ExtensionType.JSON, ANALYSER_METADATA, ExtensionState.OPTIONAL);
+        ext.setJSON(metadata);
+        feature.getExtensions().add(ext);
+
+        return feature;
+    }
+
+    private JsonObject systemBundle(final Feature feature) {
+        final Extension ext = feature.getExtensions().getByName(ANALYSER_METADATA);
+        return ext.getJSONStructure().asJsonObject().getJsonObject(SYSTEM_BUNDLE_KEY);
+    }
+
+    private static Map<String, String> singletonProps(final String key, final String value) {
+        final Map<String, String> props = new HashMap<>();
+        props.put(key, value);
+        return props;
+    }
+
+    @Test
+    public void testRefreshSystemBundleCacheKeyRefreshesStaleKey() {
+        // The system bundle cache key was pre-computed for a single framework property, but the aggregated
+        // feature has two extra ones (as contributed by an add-on such as forms).
+        final String staleKey = SystemBundleDescriptor.createCacheKey(
+                FRAMEWORK_ID, singletonProps("sling.home", "/opt/sling"));
+
+        final Feature feature = featureWithSystemBundle(
+                staleKey,
+                "sling.home", "/opt/sling",
+                "aem.jre-17", "",
+                "org.osgi.framework.system.capabilities.extra", "osgi.ee");
+
+        final String expectedKey =
+                SystemBundleDescriptor.createCacheKey(FRAMEWORK_ID, feature.getFrameworkProperties());
+        assertNotEquals("test setup: keys must differ", staleKey, expectedKey);
+
+        new AemAggregator().refreshSystemBundleCacheKey(feature);
+
+        final JsonObject systemBundle = systemBundle(feature);
+        assertEquals("scanner cache key must be refreshed to match the aggregate framework properties",
+                expectedKey, systemBundle.getString("scannerCacheKey"));
+
+        // manifest and artifact id must be preserved
+        assertEquals(FRAMEWORK_ID.toMvnId(), systemBundle.getString("artifactId"));
+        assertEquals(
+                Json.createReader(new StringReader(SYSTEM_BUNDLE_MANIFEST)).readObject(),
+                systemBundle.getJsonObject("manifest"));
+    }
+
+    @Test
+    public void testRefreshSystemBundleCacheKeyLeavesMatchingKeyUnchanged() {
+        // The cache key already matches the feature's framework properties - it must be left untouched.
+        final Feature reference = featureWithSystemBundle("placeholder", "sling.home", "/opt/sling");
+        final String correctKey =
+                SystemBundleDescriptor.createCacheKey(FRAMEWORK_ID, reference.getFrameworkProperties());
+
+        final Feature feature = featureWithSystemBundle(correctKey, "sling.home", "/opt/sling");
+
+        new AemAggregator().refreshSystemBundleCacheKey(feature);
+
+        assertEquals(correctKey, systemBundle(feature).getString("scannerCacheKey"));
+    }
+
+    @Test
+    public void testRefreshSystemBundleCacheKeyIgnoresFeatureWithoutSystemBundle() {
+        // A feature without a system bundle entry (or without an analyser-metadata extension) must not fail.
+        final Feature noExtension = new Feature(ArtifactId.parse("g:a:1"));
+        new AemAggregator().refreshSystemBundleCacheKey(noExtension);
+
+        final Feature emptyMetadata = new Feature(ArtifactId.parse("g:a:1"));
+        final Extension ext = new Extension(ExtensionType.JSON, ANALYSER_METADATA, ExtensionState.OPTIONAL);
+        ext.setJSON("{}");
+        emptyMetadata.getExtensions().add(ext);
+        new AemAggregator().refreshSystemBundleCacheKey(emptyMetadata);
+
+        assertNull(emptyMetadata.getExtensions()
+                .getByName(ANALYSER_METADATA)
+                .getJSONStructure()
+                .asJsonObject()
+                .get(SYSTEM_BUNDLE_KEY));
     }
 }


### PR DESCRIPTION
## Description
The analyser records a pre-computed "system bundle" descriptor in the analyser-metadata extension, keyed by a scanner cache key derived from the framework artifact id plus the feature's framework properties. At analysis time the scanner looks up that cache key (computed from the feature being analysed) and only falls back to an actual framework scan on a miss.

When AemAggregator merges the SDK feature with add-on features, the resulting framework properties are the union of all inputs. Add-ons may contribute extra framework properties, so the cache key inherited from the SDK feature no longer matches the aggregate. The lookup then misses and a framework scan is triggered.

Recompute the system bundle scanner cache key against the aggregate's own framework properties after assembly (the manifest capabilities/exports describe the framework artifact itself and are left untouched). The rewrite is a no-op when the key already matches or when no system bundle entry is present.

## Related Issue

#409

## Motivation and Context

#409

## How Has This Been Tested?

Additional unit tests.

## Screenshots (if appropriate):

N/A

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
