### PR TITLE
Add GitHub Actions workflow to release to Maven Central

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -8,7 +8,7 @@
 #   GPG_OWNERTRUST    - base64-encoded `gpg --export-ownertrust`
 #   GPG_PASSPHRASE    - passphrase for the GPG key
 #
-# The release is a two-step process:
+# The release has three steps:
 #   1. Tag: bumps the version, tags it, and pushes the tag/commits (skipped
 #      entirely when dryRun is true - nothing is pushed or published).
 #   2. Publish: checks out the tag and runs `mvn deploy -Prelease`, which
@@ -16,6 +16,10 @@
 #      is not enabled, so a maintainer must review and click "Publish" in
 #      the Central Portal UI (https://central.sonatype.com/publishing) to
 #      finish the release.
+#   3. Github_Release: creates a DRAFT GitHub release. It is left as a draft
+#      because Central publication is a separate manual step (see above) -
+#      a maintainer should only publish this GitHub release once the bundle
+#      has actually been published on Central, not before.
 #
 # Deploys use an isolated local Maven repository (not the cached ~/.m2) so
 # that stray _remote.repositories / maven-metadata-local.xml files from
@@ -65,11 +69,18 @@ jobs:
 
       - name: Tag (dry run)
         if: ${{ inputs.dryRun }}
-        run: mvn -B release:clean release:prepare -DreleaseVersion=${{ inputs.releaseVersion }} -DdryRun=true -Dgpg.skip=true
+        run: >
+          mvn -B release:clean release:prepare
+          -DreleaseVersion=${{ inputs.releaseVersion }}
+          -DdryRun=true
+          -Darguments=-Dgpg.skip=true
 
       - name: Tag
         if: ${{ !inputs.dryRun }}
-        run: mvn -B release:clean release:prepare -DreleaseVersion=${{ inputs.releaseVersion }} -Dgpg.skip=true
+        run: >
+          mvn -B release:clean release:prepare
+          -DreleaseVersion=${{ inputs.releaseVersion }}
+          -Darguments=-Dgpg.skip=true
 
       - name: Store tag
         id: store-version
@@ -128,7 +139,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.Tag.outputs.tag }}
 
-      - name: Create GitHub release
+      - name: Create draft GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create ${{ needs.Tag.outputs.tag }} --title "AEM Maven Analyser Plugin ${{ needs.Tag.outputs.version }}" --generate-notes
+        run: gh release create ${{ needs.Tag.outputs.tag }} --draft --title "AEM Maven Analyser Plugin ${{ needs.Tag.outputs.version }}" --generate-notes

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -20,7 +20,7 @@
 # Deploys use an isolated local Maven repository (not the cached ~/.m2) so
 # that stray _remote.repositories / maven-metadata-local.xml files from
 # unrelated local installs can't leak into the staged bundle and fail
-# Central's validation, as happened with the 1.7.0 release.
+# Central's validation.
 
 name: Release to Maven Central
 

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -46,6 +46,7 @@ jobs:
 
     outputs:
       tag: ${{ steps.store-version.outputs.tag }}
+      version: ${{ steps.store-version.outputs.version }}
 
     steps:
       - uses: actions/checkout@v7
@@ -72,7 +73,10 @@ jobs:
 
       - name: Store tag
         id: store-version
-        run: echo "tag=$(grep ^scm.tag= release.properties | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+        run: |
+          tag="$(grep ^scm.tag= release.properties | cut -d= -f2)"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${tag#aemanalyser-maven-plugin-}" >> "$GITHUB_OUTPUT"
 
   Publish:
     needs: Tag
@@ -127,4 +131,4 @@ jobs:
       - name: Create GitHub release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release create ${{ needs.Tag.outputs.tag }} --title ${{ needs.Tag.outputs.tag }} --generate-notes
+        run: gh release create ${{ needs.Tag.outputs.tag }} --title "AEM Maven Analyser Plugin ${{ needs.Tag.outputs.version }}" --generate-notes

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,0 +1,139 @@
+# This workflow releases the project to Maven Central using the Sonatype
+# Central Portal (via central-publishing-maven-plugin, configured in pom.xml).
+#
+# Required repository secrets:
+#   SONATYPE_USERNAME, SONATYPE_PASSWORD - Central Portal user token
+#     (https://central.sonatype.org/publish/generate-portal-token/)
+#   GPG_SECRET_KEYS   - base64-encoded `gpg --export-secret-keys <key>`
+#   GPG_OWNERTRUST    - base64-encoded `gpg --export-ownertrust`
+#   GPG_PASSPHRASE    - passphrase for the GPG key
+#
+# The release is a two-step process:
+#   1. Tag: bumps the version, tags it, and pushes the tag/commits (skipped
+#      entirely when dryRun is true - nothing is pushed or published).
+#   2. Publish: checks out the tag and runs `mvn deploy -Prelease`, which
+#      uploads a signed, validated bundle to the Central Portal. autoPublish
+#      is not enabled, so a maintainer must review and click "Publish" in
+#      the Central Portal UI (https://central.sonatype.com/publishing) to
+#      finish the release.
+#
+# Deploys use an isolated local Maven repository (not the cached ~/.m2) so
+# that stray _remote.repositories / maven-metadata-local.xml files from
+# unrelated local installs can't leak into the staged bundle and fail
+# Central's validation, as happened with the 1.7.0 release.
+
+name: Release to Maven Central
+
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: 'Release version (leave empty to let OddEvenVersionPolicy pick the next even version)'
+        required: false
+      dryRun:
+        description: 'Dry run (uncheck to perform a real release)'
+        required: true
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+jobs:
+  Tag:
+    runs-on: ubuntu-latest
+    if: github.repository == 'adobe/aemanalyser-maven-plugin' && github.ref == 'refs/heads/main'
+
+    outputs:
+      tag: ${{ steps.store-version.outputs.tag }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: maven
+
+      - name: Configure git user for release commits
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email noreply@github.com
+
+      - name: Tag (dry run)
+        if: ${{ inputs.dryRun }}
+        run: mvn -B release:clean release:prepare -DreleaseVersion=${{ inputs.releaseVersion }} -DdryRun=true -Dgpg.skip=true
+
+      - name: Tag
+        if: ${{ !inputs.dryRun }}
+        run: mvn -B release:clean release:prepare -DreleaseVersion=${{ inputs.releaseVersion }} -Dgpg.skip=true
+
+      - name: Store tag
+        id: store-version
+        run: echo "tag=$(grep ^scm.tag= release.properties | cut -d= -f2)" >> "$GITHUB_OUTPUT"
+
+  Publish:
+    needs: Tag
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.dryRun }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ needs.Tag.outputs.tag }}
+
+      - name: Import GPG key
+        env:
+          GPG_SECRET_KEYS: ${{ secrets.GPG_SECRET_KEYS }}
+          GPG_OWNERTRUST: ${{ secrets.GPG_OWNERTRUST }}
+        run: |
+          if [ -z "${GPG_SECRET_KEYS}" ] || [ -z "${GPG_OWNERTRUST}" ]; then
+            echo "::error::GPG_SECRET_KEYS and/or GPG_OWNERTRUST secret is empty"
+            exit 1
+          fi
+          echo "$GPG_SECRET_KEYS" | base64 --decode | gpg --import --no-tty --batch --yes
+          echo "$GPG_OWNERTRUST" | base64 --decode | gpg --import-ownertrust --no-tty --batch --yes
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: maven
+          server-id: central
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN
+
+      - name: Deploy to Maven Central
+        env:
+          MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.SONATYPE_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: mvn -B clean deploy -Prelease -Dmaven.repo.local="${RUNNER_TEMP}/m2-release-repo"
+
+  Github_Release:
+    needs: [Tag, Publish]
+    runs-on: ubuntu-latest
+    if: ${{ !inputs.dryRun }}
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ needs.Tag.outputs.tag }}
+
+      - name: Generate release changelog
+        id: changelog
+        uses: mikepenz/release-changelog-builder-action@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          toTag: ${{ needs.Tag.outputs.tag }}
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ needs.Tag.outputs.tag }}
+          name: ${{ needs.Tag.outputs.tag }}
+          body: ${{ steps.changelog.outputs.changelog }}

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -124,16 +124,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.Tag.outputs.tag }}
 
-      - name: Generate release changelog
-        id: changelog
-        uses: mikepenz/release-changelog-builder-action@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          toTag: ${{ needs.Tag.outputs.tag }}
-
       - name: Create GitHub release
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ needs.Tag.outputs.tag }}
-          name: ${{ needs.Tag.outputs.tag }}
-          body: ${{ steps.changelog.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release create ${{ needs.Tag.outputs.tag }} --title ${{ needs.Tag.outputs.tag }} --generate-notes

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@ governing permissions and limitations under the License.
   </developers>
 
   <scm>
-    <connection>scm:git:git@github.com:adobe/aemanalyser-maven-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:adobe/aemanalyser-maven-plugin.git</developerConnection>
+    <connection>scm:git:https://github.com/adobe/aemanalyser-maven-plugin.git</connection>
+    <developerConnection>scm:git:https://github.com/adobe/aemanalyser-maven-plugin.git</developerConnection>
     <url>https://github.com/adobe/aemanalyser-maven-plugin/tree/main</url>
     <tag>HEAD</tag>
   </scm>


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/maven-release.yml`, a `workflow_dispatch` workflow that automates the currently-manual release to Maven Central via the Sonatype Central Portal.
- Two-step process: a `Tag` job runs `release:prepare` (respecting the existing `OddEvenVersionPolicy`), then a `Publish` job checks out the tag, imports GPG secrets, and runs `mvn deploy -Prelease` against an isolated local Maven repo (avoids `_remote.repositories`/`maven-metadata-local.xml` leaking into the staged bundle and failing Central's validation).
- `autoPublish` is intentionally left off in `pom.xml`, so a maintainer still reviews and clicks "Publish" in the Central Portal UI after the bundle is validated and uploaded.
- Includes a `dryRun` input (default `true`) that only runs `release:prepare -DdryRun=true` — no tag, no push, no publish — so the workflow can be exercised safely without cutting a release.
- Adds a `Github_Release` job that creates a GitHub Release (via `gh release create --generate-notes`) with a friendly title after a real release.

Closes #148

## Required secrets (not yet configured on the repo)
- `SONATYPE_USERNAME`, `SONATYPE_PASSWORD` — Central Portal user token
- `GPG_SECRET_KEYS`, `GPG_OWNERTRUST`, `GPG_PASSPHRASE`

## Test plan
- [x] Validated workflow YAML syntax
- [ ] Run the workflow manually via `workflow_dispatch` with `dryRun: true` and confirm the `Tag` job succeeds, no tag/commit is pushed, and the `Publish`/`Github_Release` jobs are skipped
- [ ] Configure the required secrets on the repo, then run a real (non-dry-run) release once ready